### PR TITLE
fix: Round Gogo transcript timestamps

### DIFF
--- a/pages/api/transcripts/_data/gg1aa17c-0a31-495c-8e9d-6179de3d3111.ts
+++ b/pages/api/transcripts/_data/gg1aa17c-0a31-495c-8e9d-6179de3d3111.ts
@@ -4,2980 +4,2484 @@ export const gogo = {
   audioUrl: `https://${process.env.VERCEL_URL}/gg1aa17c-0a31-495c-8e9d-6179de3d3111.ogg`,
   blocks: [
     {
-      end: 6.5200000000000005,
-
+      end: 6.52,
       start: 0,
-      text: 'Good day, and welcome to the first quarter 2023 GoGo Inc. earnings conference call.',
+      text: "Good day, and welcome to the first quarter 2023 GoGo Inc. earnings conference call."
     },
     {
       end: 9.58,
-
-      start: 6.5200000000000005,
-      text: 'At this time, all participants are in the listen-only mode.',
+      start: 6.52,
+      text: "At this time, all participants are in the listen-only mode."
     },
     {
       end: 13.58,
-
       start: 9.58,
-      text: 'After the speaker presentation, there will be a question and answer session.',
+      text: "After the speaker presentation, there will be a question and answer session."
     },
     {
       end: 19,
-
       start: 13.58,
-      text: 'To ask a question during the session, you will need to press star 1-1 on your telephone.',
+      text: "To ask a question during the session, you will need to press star 1-1 on your telephone."
     },
     {
       end: 23,
-
       start: 19,
-      text: 'You will then hear an automated message advising that your hand has been raised.',
+      text: "You will then hear an automated message advising that your hand has been raised."
     },
     {
       end: 26.68,
-
       start: 23,
-      text: 'To lower your hand, press star 1-1 again.',
+      text: "To lower your hand, press star 1-1 again."
     },
     {
       end: 30.06,
-
       start: 26.68,
-      text: "Please be advised that today's conference is being recorded.",
+      text: "Please be advised that today's conference is being recorded."
     },
     {
       end: 37.92,
-
       start: 30.06,
-      text: 'It is now my pleasure to introduce Vice President of Investor Relations, Will Davis.',
+      text: "It is now my pleasure to introduce Vice President of Investor Relations, Will Davis."
     },
     {
       end: 40.66,
-
       start: 37.92,
-      text: 'Thank you, Andrew, and good morning, everyone.',
+      text: "Thank you, Andrew, and good morning, everyone."
     },
     {
-      end: 45.879999999999995,
-
+      end: 45.88,
       start: 40.66,
-      text: "Welcome to GoGo's first quarter 2023 earnings conference call.",
+      text: "Welcome to GoGo's first quarter 2023 earnings conference call."
     },
     {
       end: 55.24,
-
-      start: 45.879999999999995,
-      text: 'Joining me today to talk about our results are Oakley Thorne, Chairman and CEO, and Jesse Betchman, Executive Vice President and CFO.',
+      start: 45.88,
+      text: "Joining me today to talk about our results are Oakley Thorne, Chairman and CEO, and Jesse Betchman, Executive Vice President and CFO."
     },
     {
-      end: 67.24000000000001,
-
+      end: 67.24,
       start: 55.24,
-      text: 'Before we get started, I would like to take this opportunity to remind you that during the course of this call, we may make forward-looking statements regarding future events and the future performance of the company.',
+      text: "Before we get started, I would like to take this opportunity to remind you that during the course of this call, we may make forward-looking statements regarding future events and the future performance of the company."
     },
     {
-      end: 77.52000000000001,
-
-      start: 67.24000000000001,
-      text: 'We caution you to consider the risk factors that could cause actual results to differ materially from those in the forward-looking statements on the conference call.',
+      end: 77.52,
+      start: 67.24,
+      text: "We caution you to consider the risk factors that could cause actual results to differ materially from those in the forward-looking statements on the conference call."
     },
     {
       end: 92.36,
-
-      start: 77.52000000000001,
-      text: 'Those risk factors are described in our earnings release file this morning in a more fully detailed under risk factors in our annual report on Form 10-K and 10-Q and other documents we have filed with the SEC.',
+      start: 77.52,
+      text: "Those risk factors are described in our earnings release file this morning in a more fully detailed under risk factors in our annual report on Form 10-K and 10-Q and other documents we have filed with the SEC."
     },
     {
       end: 98.78,
-
       start: 92.36,
-      text: 'In addition, please note that the date of this conference call is May 3rd, 2023.',
+      text: "In addition, please note that the date of this conference call is May 3rd, 2023."
     },
     {
       end: 104.84,
-
       start: 98.78,
-      text: 'Any forward-looking statements that we make today are based on assumptions as of the state.',
+      text: "Any forward-looking statements that we make today are based on assumptions as of the state."
     },
     {
       end: 111.84,
-
       start: 104.84,
-      text: 'We undertake no obligation to update these statements as a result of more information or future events.',
+      text: "We undertake no obligation to update these statements as a result of more information or future events."
     },
     {
       end: 116.56,
-
       start: 111.84,
-      text: 'During the call, we will present both GAAP and non-GAAP financial measures.',
+      text: "During the call, we will present both GAAP and non-GAAP financial measures."
     },
     {
-      end: 127.60000000000001,
-
+      end: 127.6,
       start: 116.56,
-      text: 'We have included a reconciliation and explanation of adjustments and other considerations of our non-GAAP measures to the most comparable GAAP measures in our first quarter earnings release.',
+      text: "We have included a reconciliation and explanation of adjustments and other considerations of our non-GAAP measures to the most comparable GAAP measures in our first quarter earnings release."
     },
     {
       end: 137.6,
-
-      start: 127.60000000000001,
-      text: 'This call is being broadcast on the Internet and available on the Investor Relations website at IR.GogoAir.com.',
+      start: 127.6,
+      text: "This call is being broadcast on the Internet and available on the Investor Relations website at IR.GogoAir.com."
     },
     {
       end: 141.4,
-
       start: 137.6,
-      text: 'The earnings press release is also available on the website.',
+      text: "The earnings press release is also available on the website."
     },
     {
       end: 145.72,
-
       start: 141.4,
-      text: "After management comments, we'll host a Q&A session with the financial community only.",
+      text: "After management comments, we'll host a Q&A session with the financial community only."
     },
     {
       end: 149.6,
-
       start: 145.72,
-      text: 'It is now my great pleasure to turn the call over to Oakley.',
+      text: "It is now my great pleasure to turn the call over to Oakley."
     },
     {
       end: 152.72,
-
       start: 149.6,
-      text: 'Thanks, Will, and good morning, everyone.',
+      text: "Thanks, Will, and good morning, everyone."
     },
     {
       end: 154.2,
-
       start: 152.72,
-      text: 'Thanks for joining us today.',
+      text: "Thanks for joining us today."
     },
     {
-      end: 157.79999999999998,
-
+      end: 157.8,
       start: 154.2,
-      text: "I'll focus my remarks on three main areas.",
+      text: "I'll focus my remarks on three main areas."
     },
     {
       end: 163.24,
-
-      start: 157.79999999999998,
-      text: "First, I'll provide a state of the business aviation industry as seen from GoGo.",
+      start: 157.8,
+      text: "First, I'll provide a state of the business aviation industry as seen from GoGo."
     },
     {
-      end: 176.76000000000002,
-
+      end: 176.76,
       start: 163.24,
-      text: "Second, I'll provide key highlights of GoGo's first quarter results, and third, I'll give an update on the key strategic initiatives we're working on to drive accelerated growth in 2024 and beyond.",
+      text: "Second, I'll provide key highlights of GoGo's first quarter results, and third, I'll give an update on the key strategic initiatives we're working on to drive accelerated growth in 2024 and beyond."
     },
     {
-      end: 182.16000000000003,
-
-      start: 176.76000000000002,
-      text: 'Jesse will then walk through our quarterly performance and 2023 outlook before we open up the call to your questions.',
+      end: 182.16,
+      start: 176.76,
+      text: "Jesse will then walk through our quarterly performance and 2023 outlook before we open up the call to your questions."
     },
     {
       end: 185.96,
-
-      start: 182.16000000000003,
-      text: 'So let me start with the state of the industry.',
+      start: 182.16,
+      text: "So let me start with the state of the industry."
     },
     {
       end: 204.76,
-
       start: 185.96,
-      text: "The business aviation industry continues to serve demand at much higher levels than the pre-pandemic period, driving excellent new installation numbers for GoGo, which we expect will translate into high margin current service revenue, the primary driver of GoGo's long-term value creation model.",
+      text: "The business aviation industry continues to serve demand at much higher levels than the pre-pandemic period, driving excellent new installation numbers for GoGo, which we expect will translate into high margin current service revenue, the primary driver of GoGo's long-term value creation model."
     },
     {
       end: 221.84,
-
       start: 204.76,
-      text: 'Though dealers and OEMs are still navigating some supply chain and labor woes, the avionics industry is in the midst of a turn to normal operations, though at higher levels, as I noted a moment ago, and with some bumps still in the road.',
+      text: "Though dealers and OEMs are still navigating some supply chain and labor woes, the avionics industry is in the midst of a turn to normal operations, though at higher levels, as I noted a moment ago, and with some bumps still in the road."
     },
     {
       end: 226.68,
-
       start: 221.84,
-      text: 'For GoGo, that means dealers are returning to normal order patterns.',
+      text: "For GoGo, that means dealers are returning to normal order patterns."
     },
     {
       end: 242.4,
-
       start: 226.68,
-      text: 'Due to the extended lead times induced by COVID and fear that supply may not be available at all, many dealers ordered more equipment than they had immediate need for over the past two years, culminating with our record-setting Q4 2022 shipments.',
+      text: "Due to the extended lead times induced by COVID and fear that supply may not be available at all, many dealers ordered more equipment than they had immediate need for over the past two years, culminating with our record-setting Q4 2022 shipments."
     },
     {
       end: 248.12,
-
       start: 242.4,
-      text: 'Fortunately for GoGo, our great production ops team was able to meet that demand.',
+      text: "Fortunately for GoGo, our great production ops team was able to meet that demand."
     },
     {
-      end: 268.96000000000004,
-
+      end: 268.96,
       start: 248.12,
-      text: "However, as lead times have come down, dealers can use current inventory for new orders and don't immediately need to backfill for those installs, which is why despite having our second best new install quarter ever, we do not have as much equipment revenue to show for those installs as we normally would.",
+      text: "However, as lead times have come down, dealers can use current inventory for new orders and don't immediately need to backfill for those installs, which is why despite having our second best new install quarter ever, we do not have as much equipment revenue to show for those installs as we normally would."
     },
     {
       end: 271.16,
-
-      start: 268.96000000000004,
-      text: "We've seen this movie before.",
+      start: 268.96,
+      text: "We've seen this movie before."
     },
     {
       end: 282.44,
-
       start: 271.16,
-      text: 'After a very strong Q4 in 2020, we suffered a 30% decline in equipment revenue in Q1 2021, only to finish 2021 with very strong equipment revenue growth for the year.',
+      text: "After a very strong Q4 in 2020, we suffered a 30% decline in equipment revenue in Q1 2021, only to finish 2021 with very strong equipment revenue growth for the year."
     },
     {
-      end: 286.32000000000005,
-
+      end: 286.32,
       start: 282.44,
-      text: 'We also saw this in 2019-20.',
+      text: "We also saw this in 2019-20."
     },
     {
       end: 295.08,
-
-      start: 286.32000000000005,
-      text: "Regardless, we're confident that our record 2022 shipments will translate into strong activations in 2023.",
+      start: 286.32,
+      text: "Regardless, we're confident that our record 2022 shipments will translate into strong activations in 2023."
     },
     {
       end: 306.68,
-
       start: 295.08,
-      text: 'According to our dealers and OEMs, 75% of GoGo inventory in the channel now has either a named customer or an aircraft serial number associated with it.',
+      text: "According to our dealers and OEMs, 75% of GoGo inventory in the channel now has either a named customer or an aircraft serial number associated with it."
     },
     {
-      end: 311.47999999999996,
-
+      end: 311.48,
       start: 306.68,
-      text: 'As for the rest of the inventory, we expect demand to take care of that.',
+      text: "As for the rest of the inventory, we expect demand to take care of that."
     },
     {
       end: 325.68,
-
-      start: 311.47999999999996,
-      text: "However, we're also launching some dealer incentives to help that process along, and we're working with some of our smaller dealers to shorten install times so that they can sell GoGo as a standalone outside of a large maintenance event.",
+      start: 311.48,
+      text: "However, we're also launching some dealer incentives to help that process along, and we're working with some of our smaller dealers to shorten install times so that they can sell GoGo as a standalone outside of a large maintenance event."
     },
     {
       end: 341.8,
-
       start: 325.68,
-      text: "We've had some great success thus far, and have brought standalone upgrade install times down to five to seven days with some dealers, and are on track to get advanced upgrades times down to three days on some models with another dealer.",
+      text: "We've had some great success thus far, and have brought standalone upgrade install times down to five to seven days with some dealers, and are on track to get advanced upgrades times down to three days on some models with another dealer."
     },
     {
       end: 346.2,
-
       start: 341.8,
-      text: 'In general, the larger dealers are extremely busy.',
+      text: "In general, the larger dealers are extremely busy."
     },
     {
       end: 355.62,
-
       start: 346.2,
-      text: 'The elevated flight activity that started with COVID is accelerating the pace at which planes need to get in for required inspections and maintenance events.',
+      text: "The elevated flight activity that started with COVID is accelerating the pace at which planes need to get in for required inspections and maintenance events."
     },
     {
-      end: 363.91999999999996,
-
+      end: 363.92,
       start: 355.62,
-      text: 'Many charter and fractional fleets literally have planes parked on the tarmac grounded until they can get into the shop for maintenance.',
+      text: "Many charter and fractional fleets literally have planes parked on the tarmac grounded until they can get into the shop for maintenance."
     },
     {
-      end: 369.71999999999997,
-
-      start: 363.91999999999996,
-      text: 'Meanwhile, dealers continue to suffer labor shortages and some parts shortages.',
+      end: 369.72,
+      start: 363.92,
+      text: "Meanwhile, dealers continue to suffer labor shortages and some parts shortages."
     },
     {
       end: 386,
-
-      start: 369.71999999999997,
-      text: 'For GoGo, this has translated into more opportunities for dealers to install our equipment, but has been tempered by dealers sometimes not having enough workers to install our equipment if the work is to occur during a fixed maintenance window.',
+      start: 369.72,
+      text: "For GoGo, this has translated into more opportunities for dealers to install our equipment, but has been tempered by dealers sometimes not having enough workers to install our equipment if the work is to occur during a fixed maintenance window."
     },
     {
       end: 392.28,
-
       start: 386,
-      text: 'Similar post-COVID return to normalcy trends temporarily impacted our AOL count in the first quarter.',
+      text: "Similar post-COVID return to normalcy trends temporarily impacted our AOL count in the first quarter."
     },
     {
       end: 395.4,
-
       start: 392.28,
-      text: 'The first is the higher level of maintenance events.',
+      text: "The first is the higher level of maintenance events."
     },
     {
       end: 401.72,
-
       start: 395.4,
-      text: "Most owners turn off their GoGo service while they're in the shop or grounded on the tarmac waiting to get into the shop.",
+      text: "Most owners turn off their GoGo service while they're in the shop or grounded on the tarmac waiting to get into the shop."
     },
     {
-      end: 405.88000000000005,
-
+      end: 405.88,
       start: 401.72,
-      text: 'The second is the increase in secondhand aircraft inventory.',
+      text: "The second is the increase in secondhand aircraft inventory."
     },
     {
       end: 425.72,
-
-      start: 405.88000000000005,
-      text: "Though still well below the historical average of 5.6% of the US fleet, there's been a big jump in used aircraft for sale this year from around 2.5% to 3.6% of the fleet, which impacts our AOL because customers typically turn off their Wi-Fi when they park the aircraft for sale.",
+      start: 405.88,
+      text: "Though still well below the historical average of 5.6% of the US fleet, there's been a big jump in used aircraft for sale this year from around 2.5% to 3.6% of the fleet, which impacts our AOL because customers typically turn off their Wi-Fi when they park the aircraft for sale."
     },
     {
       end: 435.12,
-
       start: 425.72,
-      text: 'However, those sales are also an opportunity as the new owners usually reactivate their service and often upgrade before the plane comes back into service.',
+      text: "However, those sales are also an opportunity as the new owners usually reactivate their service and often upgrade before the plane comes back into service."
     },
     {
       end: 444.16,
-
       start: 435.12,
-      text: "Taking a step back, GoGo's installed base is evidence of both our strong market position today as well as the immense opportunity we see ahead.",
+      text: "Taking a step back, GoGo's installed base is evidence of both our strong market position today as well as the immense opportunity we see ahead."
     },
     {
       end: 456.6,
-
       start: 444.16,
-      text: 'Of the 15,000 business jets in the North America market, almost 50% of them have a GoGo IFC system installed today, of which almost half are installed with Avance.',
+      text: "Of the 15,000 business jets in the North America market, almost 50% of them have a GoGo IFC system installed today, of which almost half are installed with Avance."
     },
     {
-      end: 477.40000000000003,
-
+      end: 477.4,
       start: 456.6,
-      text: "Avance is a perfect stepping stone for high performance oriented customers with easy upgrade paths to either 5G or GBB as they both utilize the same Avance infrastructure on the airplane, making it easier and cheaper to stay with GoGo and upgrade than to move to a competitor's products.",
+      text: "Avance is a perfect stepping stone for high performance oriented customers with easy upgrade paths to either 5G or GBB as they both utilize the same Avance infrastructure on the airplane, making it easier and cheaper to stay with GoGo and upgrade than to move to a competitor's products."
     },
     {
       end: 483.2,
-
-      start: 477.40000000000003,
-      text: 'For this reason, the continuing to expand Avance penetration is a cornerstone of our strategy.',
+      start: 477.4,
+      text: "For this reason, the continuing to expand Avance penetration is a cornerstone of our strategy."
     },
     {
       end: 496.92,
-
       start: 483.2,
-      text: "Meanwhile, based on our research, the rest of our customers, that's non-Avance, are generally satisfied with their current GoGo Classic product, which will continue to benefit from improvements to our ATG network.",
+      text: "Meanwhile, based on our research, the rest of our customers, that's non-Avance, are generally satisfied with their current GoGo Classic product, which will continue to benefit from improvements to our ATG network."
     },
     {
       end: 513.28,
-
       start: 496.92,
-      text: 'Our loyal install base provides a solid financial foundation for our business for years to come, and the other 50% of the business jet segment and the highly unpenetrated 10,000 aircraft turboprop market represent an opportunity for future growth.',
+      text: "Our loyal install base provides a solid financial foundation for our business for years to come, and the other 50% of the business jet segment and the highly unpenetrated 10,000 aircraft turboprop market represent an opportunity for future growth."
     },
     {
       end: 516.36,
-
       start: 513.28,
-      text: "So let's move to our Q1 performance.",
+      text: "So let's move to our Q1 performance."
     },
     {
       end: 529,
-
       start: 516.36,
-      text: 'The message is that despite some bumpiness as the industry returns to pre-COVID patterns, we had our second best new install quarter ever, and our best first quarter installs ever.',
+      text: "The message is that despite some bumpiness as the industry returns to pre-COVID patterns, we had our second best new install quarter ever, and our best first quarter installs ever."
     },
     {
-      end: 539.1999999999999,
-
+      end: 539.2,
       start: 529,
-      text: 'We delivered first quarter revenue of $98.6 million, up 6% of our prior year, driven by record service revenue, our primary value driver.',
+      text: "We delivered first quarter revenue of $98.6 million, up 6% of our prior year, driven by record service revenue, our primary value driver."
     },
     {
-      end: 547.0799999999999,
-
-      start: 539.1999999999999,
-      text: 'The impacts on our equipment revenue were most significant in January and February, but in March, shipments were back on track.',
+      end: 547.08,
+      start: 539.2,
+      text: "The impacts on our equipment revenue were most significant in January and February, but in March, shipments were back on track."
     },
     {
-      end: 557.4399999999999,
-
-      start: 547.0799999999999,
-      text: "April was much better than January and February, but still a little off track, so we feel we're on the right trajectory, but still have wood to chop to get back on the planet.",
+      end: 557.44,
+      start: 547.08,
+      text: "April was much better than January and February, but still a little off track, so we feel we're on the right trajectory, but still have wood to chop to get back on the planet."
     },
     {
-      end: 568.1600000000001,
-
-      start: 557.4399999999999,
-      text: 'Our operating metrics for the quarter were strong, with twice as many customers upgrading service as downgrading, and continuing strong aircraft retention rates of greater than 90%.',
+      end: 568.16,
+      start: 557.44,
+      text: "Our operating metrics for the quarter were strong, with twice as many customers upgrading service as downgrading, and continuing strong aircraft retention rates of greater than 90%."
     },
     {
-      end: 586.5600000000001,
-
-      start: 568.1600000000001,
-      text: 'On the bottom line, GOGO delivered first quarter adjusted EBITDA of $39.7 million, down 7% year over year, reflecting softer equipment revenue, as we just discussed, and increased spending on our strategic initiatives, which Jesse will discuss in a moment.',
+      end: 586.56,
+      start: 568.16,
+      text: "On the bottom line, GOGO delivered first quarter adjusted EBITDA of $39.7 million, down 7% year over year, reflecting softer equipment revenue, as we just discussed, and increased spending on our strategic initiatives, which Jesse will discuss in a moment."
     },
     {
       end: 592.4,
-
-      start: 586.5600000000001,
-      text: 'As for guidance, the factors I discussed in my business aviation state of the union persist.',
+      start: 586.56,
+      text: "As for guidance, the factors I discussed in my business aviation state of the union persist."
     },
     {
-      end: 611.1999999999999,
-
+      end: 611.2,
       start: 592.4,
-      text: "However, we believe we're poised for strong performance in the second half, especially given the pent-up demand we see for GOGO 5G, and we still expect to finish the year in line with the full year 2023 revenue, adjusted EBITDA, and free cash flow guidance we reiterated this morning.",
+      text: "However, we believe we're poised for strong performance in the second half, especially given the pent-up demand we see for GOGO 5G, and we still expect to finish the year in line with the full year 2023 revenue, adjusted EBITDA, and free cash flow guidance we reiterated this morning."
     },
     {
       end: 615.12,
-
-      start: 611.1999999999999,
-      text: "Now let's turn to the drivers of business aviation demand.",
+      start: 611.2,
+      text: "Now let's turn to the drivers of business aviation demand."
     },
     {
       end: 622.88,
-
       start: 615.12,
-      text: 'The underlying secular trends driving demand for business aviation connectivity remain strong and continue to support our growth runway.',
+      text: "The underlying secular trends driving demand for business aviation connectivity remain strong and continue to support our growth runway."
     },
     {
       end: 633.08,
-
       start: 622.88,
-      text: 'First, passengers who flew commercial but could afford private aviation tried flying private during COVID and have generally not gone back to commercial.',
+      text: "First, passengers who flew commercial but could afford private aviation tried flying private during COVID and have generally not gone back to commercial."
     },
     {
       end: 637.24,
-
       start: 633.08,
-      text: 'Many have now ordered their own jet or are fractional interested in jet.',
+      text: "Many have now ordered their own jet or are fractional interested in jet."
     },
     {
       end: 647.12,
-
       start: 637.24,
-      text: 'Second, the demographic of passengers is going through a shift to a younger generation that expects high quality internet connectivity wherever it goes.',
+      text: "Second, the demographic of passengers is going through a shift to a younger generation that expects high quality internet connectivity wherever it goes."
     },
     {
       end: 662.28,
-
       start: 647.12,
-      text: 'And last, almost all passengers went through a technology transformation during COVID, as we all lived in isolation and had to master heavy data consumption apps like Zoom or Teams for work and Instagram or Snapchat for our social lives.',
+      text: "And last, almost all passengers went through a technology transformation during COVID, as we all lived in isolation and had to master heavy data consumption apps like Zoom or Teams for work and Instagram or Snapchat for our social lives."
     },
     {
-      end: 679.2399999999999,
-
+      end: 679.24,
       start: 662.28,
-      text: 'These trends drove a 137% increase in data usage across our networks between pre-COVID Q1 2019 and Q1 2023, and a 79% increase in usage per hour over the same period.',
+      text: "These trends drove a 137% increase in data usage across our networks between pre-COVID Q1 2019 and Q1 2023, and a 79% increase in usage per hour over the same period."
     },
     {
-      end: 685.7199999999999,
-
-      start: 679.2399999999999,
-      text: 'Though flight counts are not a revenue driver for our business, industry observers use that as a proxy for demand.',
+      end: 685.72,
+      start: 679.24,
+      text: "Though flight counts are not a revenue driver for our business, industry observers use that as a proxy for demand."
     },
     {
       end: 698.68,
-
-      start: 685.7199999999999,
-      text: 'Our go-go fleet flights in Q1 were about even with prior year but up approximately 30% compared to Q1 2019, which represents significant growth in the overall market.',
+      start: 685.72,
+      text: "Our go-go fleet flights in Q1 were about even with prior year but up approximately 30% compared to Q1 2019, which represents significant growth in the overall market."
     },
     {
-      end: 713.5999999999999,
-
+      end: 713.6,
       start: 698.68,
-      text: 'Additionally, Wall Street analysts project that OEM jet deliveries will hit 700 this year, up from 565 three years ago, and with currently committed purchases will grow to almost 800 in 2025.',
+      text: "Additionally, Wall Street analysts project that OEM jet deliveries will hit 700 this year, up from 565 three years ago, and with currently committed purchases will grow to almost 800 in 2025."
     },
     {
-      end: 716.3599999999999,
-
-      start: 713.5999999999999,
-      text: 'Our OEM relationships are very important to us.',
+      end: 716.36,
+      start: 713.6,
+      text: "Our OEM relationships are very important to us."
     },
     {
       end: 721.88,
-
-      start: 716.3599999999999,
-      text: 'An advance is either standard or an option on all 29 models of aircraft currently in production.',
+      start: 716.36,
+      text: "An advance is either standard or an option on all 29 models of aircraft currently in production."
     },
     {
       end: 726.4,
-
       start: 721.88,
-      text: 'This is a huge advantage for us as we launch 5G and GBB.',
+      text: "This is a huge advantage for us as we launch 5G and GBB."
     },
     {
       end: 734.24,
-
       start: 726.4,
-      text: 'They are merely extensions of systems that are already certified and installable on all makes of aircraft.',
+      text: "They are merely extensions of systems that are already certified and installable on all makes of aircraft."
     },
     {
-      end: 741.3199999999999,
-
+      end: 741.32,
       start: 734.24,
-      text: 'Now let me turn to an update on our strategic initiatives and how we intend to accelerate growth with our three-pronged strategy.',
+      text: "Now let me turn to an update on our strategic initiatives and how we intend to accelerate growth with our three-pronged strategy."
     },
     {
       end: 753.32,
-
-      start: 741.3199999999999,
-      text: 'First, we want to expand our service addressable market by broadening the advanced platform product offering and adding networks to meet the needs of each segment of the BA market globally.',
+      start: 741.32,
+      text: "First, we want to expand our service addressable market by broadening the advanced platform product offering and adding networks to meet the needs of each segment of the BA market globally."
     },
     {
-      end: 766.2800000000001,
-
+      end: 766.28,
       start: 753.32,
-      text: 'Second, we want to drive customer loyalty by continually improving our networks and leveraging the advanced platform to provide easy upgrade paths as new technologies emerge.',
+      text: "Second, we want to drive customer loyalty by continually improving our networks and leveraging the advanced platform to provide easy upgrade paths as new technologies emerge."
     },
     {
-      end: 774.2800000000001,
-
-      start: 766.2800000000001,
-      text: "And third, we'll offer the best product and the best service to each segment of the market at the lowest total cost of ownership.",
+      end: 774.28,
+      start: 766.28,
+      text: "And third, we'll offer the best product and the best service to each segment of the market at the lowest total cost of ownership."
     },
     {
       end: 788,
-
-      start: 774.2800000000001,
-      text: "We're making great strides in our strategic initiatives to achieve those goals, including our 5G network, our GBB LEO offering, our FCC replacement program, and the numerous operating initiatives I discussed on the last call.",
+      start: 774.28,
+      text: "We're making great strides in our strategic initiatives to achieve those goals, including our 5G network, our GBB LEO offering, our FCC replacement program, and the numerous operating initiatives I discussed on the last call."
     },
     {
       end: 792.08,
-
       start: 788,
-      text: 'So let me start with our GOGO 5G system.',
+      text: "So let me start with our GOGO 5G system."
     },
     {
       end: 797.96,
-
       start: 792.08,
-      text: 'We remain on budget and on track for a commercial launch in the fourth quarter of this year.',
+      text: "We remain on budget and on track for a commercial launch in the fourth quarter of this year."
     },
     {
       end: 820.12,
-
       start: 797.96,
-      text: "Once live, our 5G network is expected to deliver speeds roughly 5 to 10 times faster than GOGO's current APG networks, with peak speeds up to 25 to 30 times faster, enabling multiple streaming sessions and video conference applications to be opened at the same time on the same aircraft and all at lower costs than competing satellite solutions.",
+      text: "Once live, our 5G network is expected to deliver speeds roughly 5 to 10 times faster than GOGO's current APG networks, with peak speeds up to 25 to 30 times faster, enabling multiple streaming sessions and video conference applications to be opened at the same time on the same aircraft and all at lower costs than competing satellite solutions."
     },
     {
       end: 834.28,
-
       start: 820.12,
-      text: "In the meantime, customers who want GOGO 5G service can install the Advanced L5 system today with full 5G provisions and operate on GOGO's 4G network until the 5G x3 box is available.",
+      text: "In the meantime, customers who want GOGO 5G service can install the Advanced L5 system today with full 5G provisions and operate on GOGO's 4G network until the 5G x3 box is available."
     },
     {
       end: 841.48,
-
       start: 834.28,
-      text: 'Once the x3 is ready, it can be installed quickly, and 5G service can begin immediately, saving downtime and expense.',
+      text: "Once the x3 is ready, it can be installed quickly, and 5G service can begin immediately, saving downtime and expense."
     },
     {
       end: 848.12,
-
       start: 841.48,
-      text: "We're extremely pleased by the market's excitement for GOGO 5G, evidenced by our pre-provisioning momentum.",
+      text: "We're extremely pleased by the market's excitement for GOGO 5G, evidenced by our pre-provisioning momentum."
     },
     {
       end: 852.6,
-
       start: 848.12,
-      text: 'We delivered 52 pre-provisioned chipsets to customers in Q1.',
+      text: "We delivered 52 pre-provisioned chipsets to customers in Q1."
     },
     {
       end: 862.08,
-
       start: 852.6,
-      text: 'We have 116 end customers that have signed up for pre-provisioning promotions, and we have 98 dealer purchase orders in-house.',
+      text: "We have 116 end customers that have signed up for pre-provisioning promotions, and we have 98 dealer purchase orders in-house."
     },
     {
       end: 875.44,
-
       start: 862.08,
-      text: 'We also have order commitments from four OEMs and are in discussions with several others, and we have SDCs in process for 20 aircraft models representing roughly half of the business jets in North America.',
+      text: "We also have order commitments from four OEMs and are in discussions with several others, and we have SDCs in process for 20 aircraft models representing roughly half of the business jets in North America."
     },
     {
       end: 889.2,
-
       start: 875.44,
-      text: 'Now turning to our LEO-based global broadband initiative, which adds an electronically steerable antenna to the advanced platform and adds the one-web low-earth orbit satellite constellation to our network offerings.',
+      text: "Now turning to our LEO-based global broadband initiative, which adds an electronically steerable antenna to the advanced platform and adds the one-web low-earth orbit satellite constellation to our network offerings."
     },
     {
-      end: 905.2800000000001,
-
+      end: 905.28,
       start: 889.2,
-      text: 'Antennas are particularly well-suited to business aviation because their low altitude enables an equivalent link budget with less power than with geo satellites, thereby enabling a global coverage with smaller antennas that fit better on most business aviation aircraft.',
+      text: "Antennas are particularly well-suited to business aviation because their low altitude enables an equivalent link budget with less power than with geo satellites, thereby enabling a global coverage with smaller antennas that fit better on most business aviation aircraft."
     },
     {
       end: 945.52,
-
-      start: 905.2800000000001,
-      text: 'Our goals for the global broadband offering are to, first, expand our total addressable market to include 14,000 business aircraft registered outside of North America, most of which have no access to broadband connectivity today, second, to add a satellite feature for the thousands of US super mid and heavy jets that fly global missions that have GOGO Advanced ATG installed for use over North America today, and third, drive enhanced stickiness in our core North American medium-sized and smaller aircraft figments by offering an easy path to add a LEO product if they desire more capacity.',
+      start: 905.28,
+      text: "Our goals for the global broadband offering are to, first, expand our total addressable market to include 14,000 business aircraft registered outside of North America, most of which have no access to broadband connectivity today, second, to add a satellite feature for the thousands of US super mid and heavy jets that fly global missions that have GOGO Advanced ATG installed for use over North America today, and third, drive enhanced stickiness in our core North American medium-sized and smaller aircraft figments by offering an easy path to add a LEO product if they desire more capacity."
     },
     {
       end: 962.48,
-
       start: 945.52,
-      text: 'We expect GBB will enable streaming directly from your favorite video services, multiple simultaneous video conferencing sessions, VPN access, and all the other connectivity-enabled solutions you use today, the same service levels you expect in your office or living room today.',
+      text: "We expect GBB will enable streaming directly from your favorite video services, multiple simultaneous video conferencing sessions, VPN access, and all the other connectivity-enabled solutions you use today, the same service levels you expect in your office or living room today."
     },
     {
-      end: 966.3199999999999,
-
+      end: 966.32,
       start: 962.48,
-      text: 'We continue to make great progress alongside our partners.',
+      text: "We continue to make great progress alongside our partners."
     },
     {
       end: 979,
-
-      start: 966.3199999999999,
-      text: 'OneWeb will supply the LEO network, complete its launch on its 588-satellite global constellation in April, and is on track to have the network deployed and arrow-ready in 2024, as expected.',
+      start: 966.32,
+      text: "OneWeb will supply the LEO network, complete its launch on its 588-satellite global constellation in April, and is on track to have the network deployed and arrow-ready in 2024, as expected."
     },
     {
       end: 990.92,
-
       start: 979,
-      text: 'We completed preliminary design review in February with Hughes, our partner on the antenna side, and are currently on track to deliver GBB commercially two months ahead of schedule in the second half of 2024.',
+      text: "We completed preliminary design review in February with Hughes, our partner on the antenna side, and are currently on track to deliver GBB commercially two months ahead of schedule in the second half of 2024."
     },
     {
       end: 1002.76,
-
       start: 990.92,
-      text: 'Our GBB product has received a very enthusiastic response from our OEMs, dealer partners, and fleet managers, and we hope to have some exciting news on that front in the not-so-distant future.',
+      text: "Our GBB product has received a very enthusiastic response from our OEMs, dealer partners, and fleet managers, and we hope to have some exciting news on that front in the not-so-distant future."
     },
     {
       end: 1007.76,
-
       start: 1002.76,
-      text: 'Now, let me talk about a couple of competitive advantages of GBB.',
+      text: "Now, let me talk about a couple of competitive advantages of GBB."
     },
     {
       end: 1023.16,
-
       start: 1007.76,
-      text: 'First, our small form factor antenna is designed to work on all size aircraft, while our only current LEO competitor is trying to deliver a very large antenna that will work best in the already very competitive heavy jet segment of the market.',
+      text: "First, our small form factor antenna is designed to work on all size aircraft, while our only current LEO competitor is trying to deliver a very large antenna that will work best in the already very competitive heavy jet segment of the market."
     },
     {
       end: 1031.16,
-
       start: 1023.16,
-      text: 'Second, GoGo offers much better customer service in a very small but complex and service-sensitive market.',
+      text: "Second, GoGo offers much better customer service in a very small but complex and service-sensitive market."
     },
     {
-      end: 1043.5600000000002,
-
+      end: 1043.56,
       start: 1031.16,
-      text: 'And third, GoGo will be the only inflight connectivity provider that can deliver a combination of LEO and leading ATG services, enabled by our unique advanced multi-barrier capability.',
+      text: "And third, GoGo will be the only inflight connectivity provider that can deliver a combination of LEO and leading ATG services, enabled by our unique advanced multi-barrier capability."
     },
     {
       end: 1062,
-
-      start: 1043.5600000000002,
-      text: 'Together, the combination of GoGo 5G and GBB will deliver a truly unparalleled experience for passengers using heavy data applications like Zoom or gaming, offering a unique performance advantage over competitors by virtue of our proprietary ATG spectrum and technology.',
+      start: 1043.56,
+      text: "Together, the combination of GoGo 5G and GBB will deliver a truly unparalleled experience for passengers using heavy data applications like Zoom or gaming, offering a unique performance advantage over competitors by virtue of our proprietary ATG spectrum and technology."
     },
     {
       end: 1069.76,
-
       start: 1062,
-      text: "Importantly, we're well positioned to leverage our existing international footprint to support GBB customers outside the US.",
+      text: "Importantly, we're well positioned to leverage our existing international footprint to support GBB customers outside the US."
     },
     {
       end: 1077.24,
-
       start: 1069.76,
-      text: 'The 20-plus dealer is already in place and 900 narrowband customers in 90 countries today.',
+      text: "The 20-plus dealer is already in place and 900 narrowband customers in 90 countries today."
     },
     {
       end: 1082.64,
-
       start: 1077.24,
-      text: "Before turning it over to Jesse, I'd like to provide an update on our FCC reimbursement program.",
+      text: "Before turning it over to Jesse, I'd like to provide an update on our FCC reimbursement program."
     },
     {
-      end: 1092.1200000000001,
-
+      end: 1092.12,
       start: 1082.64,
-      text: "Last summer, GoGo was awarded a $334 million grant under the Federal Communication Commission's Secure and Trusted Communications Networks program.",
+      text: "Last summer, GoGo was awarded a $334 million grant under the Federal Communication Commission's Secure and Trusted Communications Networks program."
     },
     {
       end: 1100.92,
-
-      start: 1092.1200000000001,
-      text: 'It would reimburse the company for expenses associated with accelerating the removal of Chinese telecom technology from the 3G and 4G networks.',
+      start: 1092.12,
+      text: "It would reimburse the company for expenses associated with accelerating the removal of Chinese telecom technology from the 3G and 4G networks."
     },
     {
       end: 1112.6,
-
       start: 1100.92,
-      text: "Because there were more qualified grants than originally planned, all grants were cut back to 39% of the original award, which in GoGo's case is $132 million.",
+      text: "Because there were more qualified grants than originally planned, all grants were cut back to 39% of the original award, which in GoGo's case is $132 million."
     },
     {
-      end: 1121.7199999999998,
-
+      end: 1121.72,
       start: 1112.6,
-      text: 'And with bipartisan support has just been introduced, it would fully fund the grants awarded by the FCC, and we are hopeful that that will be approved.',
+      text: "And with bipartisan support has just been introduced, it would fully fund the grants awarded by the FCC, and we are hopeful that that will be approved."
     },
     {
       end: 1143.96,
-
-      start: 1121.7199999999998,
-      text: 'Because the functionality of replacement ground-based equipment will be better than the equipment installed on our 3G and 4G networks today, GoGo will get some significant benefits from this network refresh, including a 40% improvement in connectivity performance for Advanced L3 operators, and an almost doubling of the number of aircraft the network can simultaneously hand.',
+      start: 1121.72,
+      text: "Because the functionality of replacement ground-based equipment will be better than the equipment installed on our 3G and 4G networks today, GoGo will get some significant benefits from this network refresh, including a 40% improvement in connectivity performance for Advanced L3 operators, and an almost doubling of the number of aircraft the network can simultaneously hand."
     },
     {
       end: 1155.56,
-
       start: 1143.96,
-      text: 'Jesse will provide some directional guidance on the expected financial impact of this program, which is not yet reflected in our guidance, and which we will address on our Q2 earnings call.',
+      text: "Jesse will provide some directional guidance on the expected financial impact of this program, which is not yet reflected in our guidance, and which we will address on our Q2 earnings call."
     },
     {
       end: 1160.36,
-
       start: 1155.56,
-      text: "Jesse will also provide more detail on our recent $100 million debt pay down and our Moody's upgrade.",
+      text: "Jesse will also provide more detail on our recent $100 million debt pay down and our Moody's upgrade."
     },
     {
       end: 1164.8,
-
       start: 1160.36,
-      text: 'I will just state that we are committed to using our capital wisely.',
+      text: "I will just state that we are committed to using our capital wisely."
     },
     {
       end: 1179.44,
-
       start: 1164.8,
-      text: 'While returning capital to shareholders remains a priority given the current interest rate environment and that our interest rate hedge will come down by $125 million in July, we thought it was most prudent to reduce our leverage at the current time.',
+      text: "While returning capital to shareholders remains a priority given the current interest rate environment and that our interest rate hedge will come down by $125 million in July, we thought it was most prudent to reduce our leverage at the current time."
     },
     {
       end: 1191.56,
-
       start: 1179.44,
-      text: "Overall, we're excited about the future and believe GoGo has the right strategy in place to continue to capitalize on the significant opportunity in our market and deliver long-term value creation.",
+      text: "Overall, we're excited about the future and believe GoGo has the right strategy in place to continue to capitalize on the significant opportunity in our market and deliver long-term value creation."
     },
     {
-      end: 1207.3999999999999,
-
+      end: 1207.4,
       start: 1191.56,
-      text: "We're confident that our fundamental business model provides a strong foundation to support the strategic and operational initiatives we have underway and that our investment strategy continues to support a release of free cash flow in 2025 and beyond.",
+      text: "We're confident that our fundamental business model provides a strong foundation to support the strategic and operational initiatives we have underway and that our investment strategy continues to support a release of free cash flow in 2025 and beyond."
     },
     {
       end: 1209.44,
-
-      start: 1207.3999999999999,
-      text: "And now I'll turn it to Jesse for the numbers.",
+      start: 1207.4,
+      text: "And now I'll turn it to Jesse for the numbers."
     },
     {
       end: 1213.32,
-
       start: 1209.44,
-      text: 'Thanks, Oak, and good morning, everyone.',
+      text: "Thanks, Oak, and good morning, everyone."
     },
     {
       end: 1223.24,
-
       start: 1213.32,
-      text: "GoGo continues to generate strong financial performance even as we've undertaken significant strategic investments like GoGo 5G and our Global Broadband Product or GBB.",
+      text: "GoGo continues to generate strong financial performance even as we've undertaken significant strategic investments like GoGo 5G and our Global Broadband Product or GBB."
     },
     {
       end: 1229.48,
-
       start: 1223.24,
-      text: 'This is a true testament to the strength of our underlying business model and financial position.',
+      text: "This is a true testament to the strength of our underlying business model and financial position."
     },
     {
       end: 1235.02,
-
       start: 1229.48,
-      text: "In my remarks today, I'll start by walking through GoGo's first quarter financial performance in more detail.",
+      text: "In my remarks today, I'll start by walking through GoGo's first quarter financial performance in more detail."
     },
     {
       end: 1249.84,
-
       start: 1235.02,
-      text: "Then I'll provide an update on our balance sheet and capital allocation strategy, including the pay down of debt we executed today, and I'll finish up with some additional comments on our 2023 and long-term outlook.",
+      text: "Then I'll provide an update on our balance sheet and capital allocation strategy, including the pay down of debt we executed today, and I'll finish up with some additional comments on our 2023 and long-term outlook."
     },
     {
       end: 1256.04,
-
       start: 1249.84,
-      text: 'Total revenue of $98.6 million in the first quarter grew 6% year-over-year.',
+      text: "Total revenue of $98.6 million in the first quarter grew 6% year-over-year."
     },
     {
       end: 1265.96,
-
       start: 1256.04,
-      text: 'Our top line was driven by record service revenue of $78.5 million, up 11% year-over-year and 1% sequentially.',
+      text: "Our top line was driven by record service revenue of $78.5 million, up 11% year-over-year and 1% sequentially."
     },
     {
       end: 1278.96,
-
       start: 1265.96,
-      text: 'Our ATG aircraft online reached a record 7,046 units as of the end of the first quarter, including 8% growth versus the prior year and 2% growth sequentially.',
+      text: "Our ATG aircraft online reached a record 7,046 units as of the end of the first quarter, including 8% growth versus the prior year and 2% growth sequentially."
     },
     {
-      end: 1289.5600000000002,
-
+      end: 1289.56,
       start: 1278.96,
-      text: 'Advanced units online grew to 3,447 units, up 28% year-over-year, and now comprise 49% of our total fleet.',
+      text: "Advanced units online grew to 3,447 units, up 28% year-over-year, and now comprise 49% of our total fleet."
     },
     {
       end: 1304.08,
-
-      start: 1289.5600000000002,
-      text: 'We expect our advanced aircraft online growth rate to accelerate in the coming months as dealers resolve staffing challenges that are contributing to slower installation rates and more of the equipment we shipped at the end of last year is brought online.',
+      start: 1289.56,
+      text: "We expect our advanced aircraft online growth rate to accelerate in the coming months as dealers resolve staffing challenges that are contributing to slower installation rates and more of the equipment we shipped at the end of last year is brought online."
     },
     {
       end: 1321.24,
-
       start: 1304.08,
-      text: 'We continue to expect the primary service revenue growth driver to be from additional aircraft online as we execute in a global market that is only 22% penetrated with in-flight connectivity, and we launch two new products, 5G and GBB.',
+      text: "We continue to expect the primary service revenue growth driver to be from additional aircraft online as we execute in a global market that is only 22% penetrated with in-flight connectivity, and we launch two new products, 5G and GBB."
     },
     {
       end: 1331.56,
-
       start: 1321.24,
-      text: 'Total ATG R2 grew 2% year-over-year to $3,389, driven by recurring revenue and higher price service plans.',
+      text: "Total ATG R2 grew 2% year-over-year to $3,389, driven by recurring revenue and higher price service plans."
     },
     {
       end: 1344.92,
-
       start: 1331.56,
-      text: 'The launch of ZOGO 5G and Q4 this year, followed by our GBB product in the second half of 2024, are catalysts to further expand our pre-growth opportunity over time.',
+      text: "The launch of ZOGO 5G and Q4 this year, followed by our GBB product in the second half of 2024, are catalysts to further expand our pre-growth opportunity over time."
     },
     {
       end: 1360.04,
-
       start: 1344.92,
-      text: 'Moving to equipment, ZOGO delivered $20.1 million in equipment revenue in the first quarter, a 9% decrease year-over-year and 35% decrease sequentially from the seasonally high and records-worth quarter.',
+      text: "Moving to equipment, ZOGO delivered $20.1 million in equipment revenue in the first quarter, a 9% decrease year-over-year and 35% decrease sequentially from the seasonally high and records-worth quarter."
     },
     {
       end: 1382.36,
-
       start: 1360.04,
-      text: 'We shipped 223 advanced units this quarter, down 9% year-over-year and down 43% sequentially, reflecting standard seasonality for our business that was particularly pronounced due to record shipments in the second half of last year, as well as the normalization towards pre-pandemic order dynamics that Oak had discussed.',
+      text: "We shipped 223 advanced units this quarter, down 9% year-over-year and down 43% sequentially, reflecting standard seasonality for our business that was particularly pronounced due to record shipments in the second half of last year, as well as the normalization towards pre-pandemic order dynamics that Oak had discussed."
     },
     {
       end: 1395.08,
-
       start: 1382.36,
-      text: 'We remain confident that the strong, secular, underlying drivers of IFC demand and our strong position in an under-penetrated BA market will continue to propel our equipment sales in the future.',
+      text: "We remain confident that the strong, secular, underlying drivers of IFC demand and our strong position in an under-penetrated BA market will continue to propel our equipment sales in the future."
     },
     {
-      end: 1402.6399999999999,
-
+      end: 1402.64,
       start: 1395.08,
-      text: 'We ended the quarter with a strong backlog and about half of our expected 2023 equipment revenue budget already secured.',
+      text: "We ended the quarter with a strong backlog and about half of our expected 2023 equipment revenue budget already secured."
     },
     {
       end: 1414.4,
-
-      start: 1402.6399999999999,
-      text: "Overall, we're expecting our 2023 top-line performance to skew towards the second half of the year, with stronger activations and shipments in the third and fourth quarters.",
+      start: 1402.64,
+      text: "Overall, we're expecting our 2023 top-line performance to skew towards the second half of the year, with stronger activations and shipments in the third and fourth quarters."
     },
     {
       end: 1427.4,
-
       start: 1414.4,
-      text: 'Now turning to profitability, ZOGO delivered strong service margins of 79% in the first quarter, consistent with the prior year period and slightly above our budget, driven by lower network costs.',
+      text: "Now turning to profitability, ZOGO delivered strong service margins of 79% in the first quarter, consistent with the prior year period and slightly above our budget, driven by lower network costs."
     },
     {
       end: 1438.04,
-
       start: 1427.4,
-      text: 'We continue to expect long-term service margins in the 75-plus percent range and to be the primary lever for free cash flow generation and long-term value creation.',
+      text: "We continue to expect long-term service margins in the 75-plus percent range and to be the primary lever for free cash flow generation and long-term value creation."
     },
     {
-      end: 1447.8799999999999,
-
+      end: 1447.88,
       start: 1438.04,
-      text: 'Current margins were 10% in the first quarter, 26 percentage points lower than the prior year period, and 22 percentage points lower sequentially.',
+      text: "Current margins were 10% in the first quarter, 26 percentage points lower than the prior year period, and 22 percentage points lower sequentially."
     },
     {
       end: 1459.96,
-
-      start: 1447.8799999999999,
-      text: 'The decrease in our equipment margin was primarily due to additional costs related to the FCC reimbursement program and increased production costs driven by our expected 5G launch in the fourth quarter.',
+      start: 1447.88,
+      text: "The decrease in our equipment margin was primarily due to additional costs related to the FCC reimbursement program and increased production costs driven by our expected 5G launch in the fourth quarter."
     },
     {
-      end: 1471.2399999999998,
-
+      end: 1471.24,
       start: 1459.96,
-      text: 'As Oak described, we have determined to participate in the FCC reimbursement program, and by doing this, we incurred $1.3 million in inventory write-off costs.',
+      text: "As Oak described, we have determined to participate in the FCC reimbursement program, and by doing this, we incurred $1.3 million in inventory write-off costs."
     },
     {
       end: 1483.8,
-
-      start: 1471.2399999999998,
-      text: 'In addition, we incurred $1 million in cost this quarter, replacing a large number of EVDO air cards in advanced-equipped aircraft with dual-modem air cards.',
+      start: 1471.24,
+      text: "In addition, we incurred $1 million in cost this quarter, replacing a large number of EVDO air cards in advanced-equipped aircraft with dual-modem air cards."
     },
     {
-      end: 1488.8799999999999,
-
+      end: 1488.88,
       start: 1483.8,
-      text: 'These FCC-related costs drove down equipment margins by 12 percentage points.',
+      text: "These FCC-related costs drove down equipment margins by 12 percentage points."
     },
     {
       end: 1496.56,
-
-      start: 1488.8799999999999,
-      text: 'We expect equipment margins to go back to plan levels in the 25-30% range in the quarters ahead.',
+      start: 1488.88,
+      text: "We expect equipment margins to go back to plan levels in the 25-30% range in the quarters ahead."
     },
     {
       end: 1513.28,
-
       start: 1496.56,
-      text: 'Now moving on to operating expenses, first quarter combined engineering, design, and development, sales and marketing, and general and administrative expenses increased 15% year-over-year to $29 million, and on a sequential basis, operating expenses were flat.',
+      text: "Now moving on to operating expenses, first quarter combined engineering, design, and development, sales and marketing, and general and administrative expenses increased 15% year-over-year to $29 million, and on a sequential basis, operating expenses were flat."
     },
     {
       end: 1519.52,
-
       start: 1513.28,
-      text: 'The year-over-year increase reflects development expenses for GBB as well as higher personnel costs.',
+      text: "The year-over-year increase reflects development expenses for GBB as well as higher personnel costs."
     },
     {
-      end: 1530.8799999999999,
-
+      end: 1530.88,
       start: 1519.52,
-      text: 'As we previously stated, we expect that 2023 and 2024 will continue to be investment years as we complete our 5G program and ramp up spending for GBB.',
+      text: "As we previously stated, we expect that 2023 and 2024 will continue to be investment years as we complete our 5G program and ramp up spending for GBB."
     },
     {
       end: 1545.72,
-
-      start: 1530.8799999999999,
-      text: 'We continue to anticipate that these investments will support sustained, strong, top-line growth, and once completed, will be a key driver to significant free cash flow growth in 2025 and beyond.',
+      start: 1530.88,
+      text: "We continue to anticipate that these investments will support sustained, strong, top-line growth, and once completed, will be a key driver to significant free cash flow growth in 2025 and beyond."
     },
     {
       end: 1555.04,
-
       start: 1545.72,
-      text: "In terms of GOGO 5G spending, we continue to stay on track and on budget for GOGO's 5G's commercial launch in the fourth quarter of 2023.",
+      text: "In terms of GOGO 5G spending, we continue to stay on track and on budget for GOGO's 5G's commercial launch in the fourth quarter of 2023."
     },
     {
       end: 1567.88,
-
       start: 1555.04,
-      text: 'While our timeline has shifted, we have remained on track with the cost expectations we set back in 2019 that GOGO 5G and external development and deployment costs would be approximately $100 million.',
+      text: "While our timeline has shifted, we have remained on track with the cost expectations we set back in 2019 that GOGO 5G and external development and deployment costs would be approximately $100 million."
     },
     {
       end: 1579.24,
-
       start: 1567.88,
-      text: 'In the first quarter, our $2.6 million of 5G spending was comprised of $2.2 million in CAPEX and $0.4 million in OPEX.',
+      text: "In the first quarter, our $2.6 million of 5G spending was comprised of $2.2 million in CAPEX and $0.4 million in OPEX."
     },
     {
       end: 1581.96,
-
       start: 1579.24,
-      text: 'Now on to our GBB initiative.',
+      text: "Now on to our GBB initiative."
     },
     {
       end: 1589.32,
-
       start: 1581.96,
-      text: 'In the first quarter, GOGO incurred $1.5 million in operating expenses related to GBB.',
+      text: "In the first quarter, GOGO incurred $1.5 million in operating expenses related to GBB."
     },
     {
       end: 1601.72,
-
       start: 1589.32,
-      text: 'We continue to expect external development costs for GBB to be less than $50 million over three years with approximately $14 million in 2023 and the remaining spending to occur in 2024.',
+      text: "We continue to expect external development costs for GBB to be less than $50 million over three years with approximately $14 million in 2023 and the remaining spending to occur in 2024."
     },
     {
       end: 1611.48,
-
       start: 1601.72,
-      text: 'As we previously stated, we anticipate that approximately 95% of GBB external development costs will be in OPEX.',
+      text: "As we previously stated, we anticipate that approximately 95% of GBB external development costs will be in OPEX."
     },
     {
       end: 1619.16,
-
       start: 1611.48,
-      text: 'This spending profile is reflected in our 2023 adjusted EBITDA and free cash flow guidance.',
+      text: "This spending profile is reflected in our 2023 adjusted EBITDA and free cash flow guidance."
     },
     {
       end: 1634.64,
-
       start: 1619.16,
-      text: "Moving on to our bottom line, GOGO's first quarter adjusted EBITDA decreased 7% year over year to $39.7 million, primarily due to lower equipment revenues and increased operating expenses, including GBB.",
+      text: "Moving on to our bottom line, GOGO's first quarter adjusted EBITDA decreased 7% year over year to $39.7 million, primarily due to lower equipment revenues and increased operating expenses, including GBB."
     },
     {
       end: 1648.76,
-
       start: 1634.64,
-      text: 'GOGO delivered net income of $20.4 million in the first quarter, down 8% year over year, translating to $0.16 in basic earnings per share and $0.15 in diluted earnings per share.',
+      text: "GOGO delivered net income of $20.4 million in the first quarter, down 8% year over year, translating to $0.16 in basic earnings per share and $0.15 in diluted earnings per share."
     },
     {
       end: 1655.8,
-
       start: 1648.76,
-      text: 'As a reminder, our financial statements reflect non-cash income tax expenses as we continue to generate positive pre-tax income.',
+      text: "As a reminder, our financial statements reflect non-cash income tax expenses as we continue to generate positive pre-tax income."
     },
     {
       end: 1668.48,
-
       start: 1655.8,
-      text: 'Based on our substantial NOL position, we did not expect to pay meaningful cash taxes for an extended period, but we may pay a modest amount by the end of our planning horizon.',
+      text: "Based on our substantial NOL position, we did not expect to pay meaningful cash taxes for an extended period, but we may pay a modest amount by the end of our planning horizon."
     },
     {
       end: 1679.2,
-
       start: 1668.48,
-      text: 'We continue to expect additional reversals of portions of evaluation allowance against deferred tax assets within the 2023 fiscal year.',
+      text: "We continue to expect additional reversals of portions of evaluation allowance against deferred tax assets within the 2023 fiscal year."
     },
     {
-      end: 1694.7199999999998,
-
+      end: 1694.72,
       start: 1679.2,
-      text: 'In the first quarter, we generated $20 million in free cash flow, up $11.2 million compared to Q1 2022 due to a decrease in networking capital from lower accounts receivable and lower 5G capex.',
+      text: "In the first quarter, we generated $20 million in free cash flow, up $11.2 million compared to Q1 2022 due to a decrease in networking capital from lower accounts receivable and lower 5G capex."
     },
     {
-      end: 1703.1999999999998,
-
-      start: 1694.7199999999998,
-      text: 'Free cash flow was down $5 million sequentially, primarily driven by employee bonus payments made in the first quarter.',
+      end: 1703.2,
+      start: 1694.72,
+      text: "Free cash flow was down $5 million sequentially, primarily driven by employee bonus payments made in the first quarter."
     },
     {
-      end: 1706.8799999999999,
-
-      start: 1703.1999999999998,
-      text: "Now I'll turn to a discussion on our balance sheet.",
+      end: 1706.88,
+      start: 1703.2,
+      text: "Now I'll turn to a discussion on our balance sheet."
     },
     {
       end: 1722.24,
-
-      start: 1706.8799999999999,
-      text: 'We ended the quarter with $712.3 million in outstanding principal on our term loan and $188 million in cash and short-term investments with our $100 million revolver remaining undrawn.',
+      start: 1706.88,
+      text: "We ended the quarter with $712.3 million in outstanding principal on our term loan and $188 million in cash and short-term investments with our $100 million revolver remaining undrawn."
     },
     {
       end: 1731.76,
-
       start: 1722.24,
-      text: 'At the end of the quarter, GOGO had a net leverage of 3.1 times in line with our target range of 2.5 to 3.5 times.',
+      text: "At the end of the quarter, GOGO had a net leverage of 3.1 times in line with our target range of 2.5 to 3.5 times."
     },
     {
       end: 1742.6,
-
       start: 1731.76,
-      text: 'As we announced on May 1st, GOGO made a strategic decision to pay down an aggregate principal amount of $100 million on our outstanding term loan debt facility.',
+      text: "As we announced on May 1st, GOGO made a strategic decision to pay down an aggregate principal amount of $100 million on our outstanding term loan debt facility."
     },
     {
       end: 1756,
-
       start: 1742.6,
-      text: 'As mentioned on previous calls, while we have a hedge agreement in place and before the pay down were more than 90% hedged, the first step down to $525 million will occur in July.',
+      text: "As mentioned on previous calls, while we have a hedge agreement in place and before the pay down were more than 90% hedged, the first step down to $525 million will occur in July."
     },
     {
       end: 1766.72,
-
       start: 1756,
-      text: 'The pay down will materially reduce our interest expense, minimizing our exposure to the current volatile financial environments and ultimately strengthen our financial and strategic flexibility.',
+      text: "The pay down will materially reduce our interest expense, minimizing our exposure to the current volatile financial environments and ultimately strengthen our financial and strategic flexibility."
     },
     {
       end: 1775.72,
-
       start: 1766.72,
-      text: 'As a result of the pay down, GOGO will reduce its term loan B outstanding principal to $612.3 million.',
+      text: "As a result of the pay down, GOGO will reduce its term loan B outstanding principal to $612.3 million."
     },
     {
       end: 1784.48,
-
       start: 1775.72,
-      text: 'Gross leverage at the end of Q1 was 4.2 times and it will be reduced to 3.6 times after the pay down.',
+      text: "Gross leverage at the end of Q1 was 4.2 times and it will be reduced to 3.6 times after the pay down."
     },
     {
       end: 1804.76,
-
       start: 1784.48,
-      text: 'On an annualized basis, we expect to reduce cash interest by approximately $8.5 million based on current SOPA rates and in 2023, interest costs will be reduced by approximately $4.5 million based on the April forward SOPA curve and $50 million to net worth work on interest income.',
+      text: "On an annualized basis, we expect to reduce cash interest by approximately $8.5 million based on current SOPA rates and in 2023, interest costs will be reduced by approximately $4.5 million based on the April forward SOPA curve and $50 million to net worth work on interest income."
     },
     {
       end: 1818.36,
-
       start: 1804.76,
-      text: "As a result of executing a more conservative financial policy with a lower leverage target and pay down of debt, this week Moody's upgraded our credit rating to B1 with a stable outlook.",
+      text: "As a result of executing a more conservative financial policy with a lower leverage target and pay down of debt, this week Moody's upgraded our credit rating to B1 with a stable outlook."
     },
     {
-      end: 1822.6799999999998,
-
+      end: 1822.68,
       start: 1818.36,
-      text: 'The pay down of our debt is in line with our balanced capital allocation strategy.',
+      text: "The pay down of our debt is in line with our balanced capital allocation strategy."
     },
     {
-      end: 1852.1599999999999,
-
-      start: 1822.6799999999998,
-      text: 'As a reminder, our priorities are first to maintain adequate liquidity, second investing in strategic opportunities to drive competitive positioning and financial value including 5G and GBB, third maintaining an appropriate level of leverage for the economic environment with a target net leverage ratio of 2.5 to 3.5 times and finally returning capital to shareholders as appropriate in the future.',
+      end: 1852.16,
+      start: 1822.68,
+      text: "As a reminder, our priorities are first to maintain adequate liquidity, second investing in strategic opportunities to drive competitive positioning and financial value including 5G and GBB, third maintaining an appropriate level of leverage for the economic environment with a target net leverage ratio of 2.5 to 3.5 times and finally returning capital to shareholders as appropriate in the future."
     },
     {
       end: 1853.84,
-
-      start: 1852.1599999999999,
-      text: "Now I'll turn to our outlook.",
+      start: 1852.16,
+      text: "Now I'll turn to our outlook."
     },
     {
       end: 1859.28,
-
       start: 1853.84,
-      text: 'GOGO is reiterating our fiscal 2023 financial guidance and long-term targets.',
+      text: "GOGO is reiterating our fiscal 2023 financial guidance and long-term targets."
     },
     {
       end: 1866.32,
-
       start: 1859.28,
-      text: 'We continue to target 2023 revenue in the range of $440 to $455 million.',
+      text: "We continue to target 2023 revenue in the range of $440 to $455 million."
     },
     {
       end: 1889.12,
-
       start: 1866.32,
-      text: "While we've had a slower start to 2023 due to the dynamics we've discussed earlier, we continue to believe 2023 will be a strong year for aircraft online growth as the record units we shift in 2023 are activated, driving recurring high margin service revenue and equipment additional equipment sales follow, particularly in the second half of the year.",
+      text: "While we've had a slower start to 2023 due to the dynamics we've discussed earlier, we continue to believe 2023 will be a strong year for aircraft online growth as the record units we shift in 2023 are activated, driving recurring high margin service revenue and equipment additional equipment sales follow, particularly in the second half of the year."
     },
     {
       end: 1930.84,
-
       start: 1889.12,
-      text: 'We expect 2023 adjusted EBITDA in the range of $150 to $160 million, reflecting operating expenses of approximately $30 million for strategic and operational initiatives including $9 million in expected 5G spending, which reflects the shift of $6 million from 2022 to 2023 related to the chip delay, approximately $14 million in GBB development spend and approximately $7 million in additional operational initiatives focused on penetrating the 78% of the global business aviation and flight connectivity market that remains untapped and maintaining our long-term competitiveness.',
+      text: "We expect 2023 adjusted EBITDA in the range of $150 to $160 million, reflecting operating expenses of approximately $30 million for strategic and operational initiatives including $9 million in expected 5G spending, which reflects the shift of $6 million from 2022 to 2023 related to the chip delay, approximately $14 million in GBB development spend and approximately $7 million in additional operational initiatives focused on penetrating the 78% of the global business aviation and flight connectivity market that remains untapped and maintaining our long-term competitiveness."
     },
     {
       end: 1946.52,
-
       start: 1930.84,
-      text: 'We expect 2023 free cash flow of $80 million to $90 million, which includes capital expenditures of approximately $30 million to $40 million, of which $20 million is tied to global 5G.',
+      text: "We expect 2023 free cash flow of $80 million to $90 million, which includes capital expenditures of approximately $30 million to $40 million, of which $20 million is tied to global 5G."
     },
     {
       end: 1957,
-
       start: 1946.52,
-      text: 'Even with our investments in exciting new products, we expect year-over-year free cash flow growth in 2023 of nearly 50% at the midpoint of the guidance.',
+      text: "Even with our investments in exciting new products, we expect year-over-year free cash flow growth in 2023 of nearly 50% at the midpoint of the guidance."
     },
     {
       end: 1967.96,
-
       start: 1957,
-      text: "Importantly, our 2020's guidance does not reflect the impact of GOA's participation in the FCC's Secure and Trusted Communications Networks Reimbursement Program.",
+      text: "Importantly, our 2020's guidance does not reflect the impact of GOA's participation in the FCC's Secure and Trusted Communications Networks Reimbursement Program."
     },
     {
       end: 1976,
-
       start: 1967.96,
-      text: 'As previously mentioned, GOGA plans to proceed with the FCC program by submitting an initial reimbursement request before the July deadline.',
+      text: "As previously mentioned, GOGA plans to proceed with the FCC program by submitting an initial reimbursement request before the July deadline."
     },
     {
       end: 1989.04,
-
       start: 1976,
-      text: 'Since the program is currently partially funded, we have some optionality in what we request reimbursement for that could impact where grant money received will be recorded between the income statement and balance sheet.',
+      text: "Since the program is currently partially funded, we have some optionality in what we request reimbursement for that could impact where grant money received will be recorded between the income statement and balance sheet."
     },
     {
-      end: 2001.6399999999999,
-
+      end: 2001.64,
       start: 1989.04,
-      text: 'We will be solidifying our plans over the next couple of months, but in the interim, I want to provide some directional context on how the reimbursement program could impact our 2023 outlook.',
+      text: "We will be solidifying our plans over the next couple of months, but in the interim, I want to provide some directional context on how the reimbursement program could impact our 2023 outlook."
     },
     {
       end: 2012.36,
-
-      start: 2001.6399999999999,
-      text: 'At a high level, we expect 2023 free cash flow to be impacted by increased use of working capital as we build airborne inventory and tower equipment.',
+      start: 2001.64,
+      text: "At a high level, we expect 2023 free cash flow to be impacted by increased use of working capital as we build airborne inventory and tower equipment."
     },
     {
-      end: 2020.7199999999998,
-
+      end: 2020.72,
       start: 2012.36,
-      text: 'The government reimbursements will partially lag those purchases, and then we see a cash flow benefit in subsequent years as the program unfolds.',
+      text: "The government reimbursements will partially lag those purchases, and then we see a cash flow benefit in subsequent years as the program unfolds."
     },
     {
-      end: 2033.1599999999999,
-
-      start: 2020.7199999999998,
-      text: 'We will update our guidance on our Q2 call to reflect the program once our plans are finalized and provide more complete information on the financial impact of the FCC reimbursement program.',
+      end: 2033.16,
+      start: 2020.72,
+      text: "We will update our guidance on our Q2 call to reflect the program once our plans are finalized and provide more complete information on the financial impact of the FCC reimbursement program."
     },
     {
       end: 2046.68,
-
-      start: 2033.1599999999999,
-      text: 'Our long-term targets also remain unchanged, reflecting our expectations for the launch of Gogo 5G in late 2023 and the launch of our GBB product in the second half of 2024.',
+      start: 2033.16,
+      text: "Our long-term targets also remain unchanged, reflecting our expectations for the launch of Gogo 5G in late 2023 and the launch of our GBB product in the second half of 2024."
     },
     {
       end: 2061.68,
-
       start: 2046.68,
-      text: 'We reiterate that we expect revenue growth at a compound annual growth rate of approximately 17% from 2022 through 2027, with global broadband materially contributing to revenue in 2025.',
+      text: "We reiterate that we expect revenue growth at a compound annual growth rate of approximately 17% from 2022 through 2027, with global broadband materially contributing to revenue in 2025."
     },
     {
-      end: 2076.3999999999996,
-
+      end: 2076.4,
       start: 2061.68,
-      text: 'We also expect annual adjusted EBITDA margin to be in the mid-40% range by 2027, which includes continued investments in engineering, design, and development to fund innovation and market competitiveness in the out years.',
+      text: "We also expect annual adjusted EBITDA margin to be in the mid-40% range by 2027, which includes continued investments in engineering, design, and development to fund innovation and market competitiveness in the out years."
     },
     {
-      end: 2085.3599999999997,
-
-      start: 2076.3999999999996,
-      text: 'And finally, we continue to expect free cash flow of more than $200 million in 2025 and growing in 2026 and beyond.',
+      end: 2085.36,
+      start: 2076.4,
+      text: "And finally, we continue to expect free cash flow of more than $200 million in 2025 and growing in 2026 and beyond."
     },
     {
       end: 2096.8,
-
-      start: 2085.3599999999997,
-      text: 'We believe that our value proposition is underpinned by the strong growth in free cash flow as we complete our 5G and GBB investments and execute in an under-penetrated global market.',
+      start: 2085.36,
+      text: "We believe that our value proposition is underpinned by the strong growth in free cash flow as we complete our 5G and GBB investments and execute in an under-penetrated global market."
     },
     {
       end: 2101.28,
-
       start: 2096.8,
-      text: "Gogo's business continues to perform extremely well.",
+      text: "Gogo's business continues to perform extremely well."
     },
     {
       end: 2114.84,
-
       start: 2101.28,
-      text: 'Our outlook underscores the immense value creation potential for our customers and shareholders that we expect to unlock as we execute our strategy and invest in the strategic initiatives that will extend and enhance our long-term growth.',
+      text: "Our outlook underscores the immense value creation potential for our customers and shareholders that we expect to unlock as we execute our strategy and invest in the strategic initiatives that will extend and enhance our long-term growth."
     },
     {
       end: 2125.6,
-
       start: 2114.84,
-      text: 'Before we open the call up for questions, I would like to thank the entire Gogo team for their continuous hard work, dedication to our business, and for providing unparalleled service to our customers.',
+      text: "Before we open the call up for questions, I would like to thank the entire Gogo team for their continuous hard work, dedication to our business, and for providing unparalleled service to our customers."
     },
     {
-      end: 2128.8399999999997,
-
+      end: 2128.84,
       start: 2125.6,
-      text: 'Operator, this concludes our prepared remarks.',
+      text: "Operator, this concludes our prepared remarks."
     },
     {
-      end: 2130.8399999999997,
-
-      start: 2128.8399999999997,
-      text: 'We are now ready to take our first question.',
+      end: 2130.84,
+      start: 2128.84,
+      text: "We are now ready to take our first question."
     },
     {
-      end: 2131.8399999999997,
-
-      start: 2130.8399999999997,
-      text: 'Thank you.',
+      end: 2131.84,
+      start: 2130.84,
+      text: "Thank you."
     },
     {
       end: 2138.44,
-
-      start: 2131.8399999999997,
-      text: 'As a reminder, to ask a question, you will need to press star 1-1 on your telephone.',
+      start: 2131.84,
+      text: "As a reminder, to ask a question, you will need to press star 1-1 on your telephone."
     },
     {
       end: 2144.36,
-
       start: 2138.44,
-      text: 'If your question has been answered or you wish to remove yourself from the queue, press star 1-1 again.',
+      text: "If your question has been answered or you wish to remove yourself from the queue, press star 1-1 again."
     },
     {
       end: 2147.36,
-
       start: 2144.36,
-      text: 'One moment, please.',
+      text: "One moment, please."
     },
     {
       end: 2153.88,
-
       start: 2147.36,
-      text: 'Our first question comes from the line of Rick Prentice with Raymond James.',
+      text: "Our first question comes from the line of Rick Prentice with Raymond James."
     },
     {
       end: 2154.88,
-
       start: 2153.88,
-      text: 'Thanks.',
+      text: "Thanks."
     },
     {
       end: 2155.88,
-
       start: 2154.88,
-      text: 'Good morning, everybody.',
+      text: "Good morning, everybody."
     },
     {
       end: 2156.88,
-
       start: 2155.88,
-      text: 'Hey, Rick.',
+      text: "Hey, Rick."
     },
     {
       end: 2157.88,
-
       start: 2156.88,
-      text: 'Hey, good morning.',
+      text: "Hey, good morning."
     },
     {
       end: 2160.88,
-
       start: 2157.88,
-      text: 'A couple questions, if I could.',
+      text: "A couple questions, if I could."
     },
     {
       end: 2172,
-
       start: 2160.88,
-      text: 'First, if you started with, obviously, the state of the business, mentioning 15,000 business shuts out there, you guys have about 50% of that, 50% are advanced.',
+      text: "First, if you started with, obviously, the state of the business, mentioning 15,000 business shuts out there, you guys have about 50% of that, 50% are advanced."
     },
     {
       end: 2177.8,
-
       start: 2172,
-      text: 'Help people understand, why do you think that market is so under-penetrated?',
+      text: "Help people understand, why do you think that market is so under-penetrated?"
     },
     {
       end: 2190.36,
-
       start: 2177.8,
-      text: 'You talked a little bit about the technology changes and demographic shifts, but help people understand how you think that curve plays out of what drives people to say, yeah, I want in-flight connectivity on that pool of business jets.',
+      text: "You talked a little bit about the technology changes and demographic shifts, but help people understand how you think that curve plays out of what drives people to say, yeah, I want in-flight connectivity on that pool of business jets."
     },
     {
       end: 2195.64,
-
       start: 2190.36,
-      text: 'And then on the 10,000 turbojets sticking with the US, what is it there?',
+      text: "And then on the 10,000 turbojets sticking with the US, what is it there?"
     },
     {
       end: 2196.64,
-
       start: 2195.64,
-      text: 'Does it require price?',
+      text: "Does it require price?"
     },
     {
       end: 2198,
-
       start: 2196.64,
-      text: 'Is it an antenna?',
+      text: "Is it an antenna?"
     },
     {
       end: 2201.4,
-
       start: 2198,
-      text: 'What is it that gets turbojets to come on board?',
+      text: "What is it that gets turbojets to come on board?"
     },
     {
       end: 2205,
-
       start: 2201.4,
-      text: 'And then the third part of the question is, obviously, the global side of it.',
+      text: "And then the third part of the question is, obviously, the global side of it."
     },
     {
       end: 2210.36,
-
       start: 2205,
-      text: "What do you think spurs people to come to say, yes, I'm ready to pay for in-flight connectivity?",
+      text: "What do you think spurs people to come to say, yes, I'm ready to pay for in-flight connectivity?"
     },
     {
       end: 2211.36,
-
       start: 2210.36,
-      text: 'Right.',
+      text: "Right."
     },
     {
       end: 2214.36,
-
       start: 2211.36,
-      text: "So we'll start with the jets.",
+      text: "So we'll start with the jets."
     },
     {
       end: 2226.28,
-
       start: 2214.36,
-      text: "You know, 50%, given that this has been line fit for, I don't know, roughly 10 years or so, I would say, isn't that bad when you think about it.",
+      text: "You know, 50%, given that this has been line fit for, I don't know, roughly 10 years or so, I would say, isn't that bad when you think about it."
     },
     {
       end: 2237.8,
-
       start: 2226.28,
-      text: 'You know, a lot of the jets are, frankly, older than significantly older than the amount of time that our service has been line fit available at the OEMs.',
+      text: "You know, a lot of the jets are, frankly, older than significantly older than the amount of time that our service has been line fit available at the OEMs."
     },
     {
-      end: 2241.2000000000003,
-
+      end: 2241.2,
       start: 2237.8,
-      text: 'So all that has to come through the aftermarket.',
+      text: "So all that has to come through the aftermarket."
     },
     {
-      end: 2247.1200000000003,
-
-      start: 2241.2000000000003,
-      text: 'And frankly, I think that service levels have to do with it.',
+      end: 2247.12,
+      start: 2241.2,
+      text: "And frankly, I think that service levels have to do with it."
     },
     {
-      end: 2258.2799999999997,
-
-      start: 2247.1200000000003,
-      text: "I think that the incredible increase in the capacity we'll be delivering with 5G and GBB, et cetera, will be a real incentive for people to install service.",
+      end: 2258.28,
+      start: 2247.12,
+      text: "I think that the incredible increase in the capacity we'll be delivering with 5G and GBB, et cetera, will be a real incentive for people to install service."
     },
     {
       end: 2263.6,
-
-      start: 2258.2799999999997,
-      text: "Second, you know, you have to do it, generally, it's taken a long time to install.",
+      start: 2258.28,
+      text: "Second, you know, you have to do it, generally, it's taken a long time to install."
     },
     {
       end: 2267.92,
-
       start: 2263.6,
-      text: "Our systems are faster to install than others, but still probably haven't been fast enough.",
+      text: "Our systems are faster to install than others, but still probably haven't been fast enough."
     },
     {
       end: 2274.88,
-
       start: 2267.92,
-      text: "So we've been really focused on reducing install times so that you not only have to wait for it, you don't have to wait for a big maintenance event.",
+      text: "So we've been really focused on reducing install times so that you not only have to wait for it, you don't have to wait for a big maintenance event."
     },
     {
       end: 2281.28,
-
       start: 2274.88,
-      text: 'You might even just go in and do a standalone upgrade or install rather.',
+      text: "You might even just go in and do a standalone upgrade or install rather."
     },
     {
       end: 2290.4,
-
       start: 2281.28,
-      text: "I'd say in the lower end of the business jet market, there's some price sensitivity, but that's where we've got L3 positioned and lower price plans that go with that.",
+      text: "I'd say in the lower end of the business jet market, there's some price sensitivity, but that's where we've got L3 positioned and lower price plans that go with that."
     },
     {
       end: 2296.52,
-
       start: 2290.4,
-      text: "So I think that's why we've been pretty successful in driving penetration of the light jet market over the last couple of years.",
+      text: "So I think that's why we've been pretty successful in driving penetration of the light jet market over the last couple of years."
     },
     {
       end: 2298.96,
-
       start: 2296.52,
-      text: "So it's a combination of all those things.",
+      text: "So it's a combination of all those things."
     },
     {
       end: 2299.96,
-
       start: 2298.96,
-      text: "It's generational.",
+      text: "It's generational."
     },
     {
       end: 2311.16,
-
       start: 2299.96,
-      text: "I mean, a lot of business jets, you know, five, 10 years ago were owned by people my age and many of those people didn't want to have connectivity on the jet or feel the need for it.",
+      text: "I mean, a lot of business jets, you know, five, 10 years ago were owned by people my age and many of those people didn't want to have connectivity on the jet or feel the need for it."
     },
     {
       end: 2312.68,
-
       start: 2311.16,
-      text: "But it's actually shifted as today.",
+      text: "But it's actually shifted as today."
     },
     {
       end: 2322.56,
-
       start: 2312.68,
-      text: 'I think we did a poll of our user base last year, you know, and 67% of them are now Gen X, Y, and Z, not baby boomers like myself.',
+      text: "I think we did a poll of our user base last year, you know, and 67% of them are now Gen X, Y, and Z, not baby boomers like myself."
     },
     {
       end: 2325.52,
-
       start: 2322.56,
-      text: 'So I think those are all contributing factors.',
+      text: "So I think those are all contributing factors."
     },
     {
       end: 2333.44,
-
       start: 2325.52,
-      text: "I think, you know, we've seen a real turn there and, you know, a much real acceleration of the number of people, you know, installing.",
+      text: "I think, you know, we've seen a real turn there and, you know, a much real acceleration of the number of people, you know, installing."
     },
     {
       end: 2336.56,
-
       start: 2333.44,
-      text: "So that's that market.",
+      text: "So that's that market."
     },
     {
       end: 2339.68,
-
       start: 2336.56,
-      text: "In the turboprop market, I think it's a couple of things.",
+      text: "In the turboprop market, I think it's a couple of things."
     },
     {
       end: 2343,
-
       start: 2339.68,
-      text: 'I think price is definitely a factor in a lot of that market.',
+      text: "I think price is definitely a factor in a lot of that market."
     },
     {
-      end: 2346.9199999999996,
-
+      end: 2346.92,
       start: 2343,
-      text: "And again, we've been trying to go down market.",
+      text: "And again, we've been trying to go down market."
     },
     {
-      end: 2352.3199999999997,
-
-      start: 2346.9199999999996,
-      text: "You know, we've announced some deals with some of the turboprop fractionals, for instance.",
+      end: 2352.32,
+      start: 2346.92,
+      text: "You know, we've announced some deals with some of the turboprop fractionals, for instance."
     },
     {
-      end: 2360.9199999999996,
-
-      start: 2352.3199999999997,
-      text: "We've got, you know, our Cirrus deal, which is actually not a turboprop, a small jet, but sort of same market in some ways.",
+      end: 2360.92,
+      start: 2352.32,
+      text: "We've got, you know, our Cirrus deal, which is actually not a turboprop, a small jet, but sort of same market in some ways."
     },
     {
       end: 2371.36,
-
-      start: 2360.9199999999996,
-      text: "But what we're seeing is, you know, more interest in, you know, from the turboprop market, especially the charter part of that market, because people expect connectivity when they charter.",
+      start: 2360.92,
+      text: "But what we're seeing is, you know, more interest in, you know, from the turboprop market, especially the charter part of that market, because people expect connectivity when they charter."
     },
     {
       end: 2373.48,
-
       start: 2371.36,
-      text: 'So I think that that is going to shift.',
+      text: "So I think that that is going to shift."
     },
     {
       end: 2381.56,
-
       start: 2373.48,
-      text: "And of course, with Avance, we've been designing new form factors that are smaller and will fit in those more compact aircraft.",
+      text: "And of course, with Avance, we've been designing new form factors that are smaller and will fit in those more compact aircraft."
     },
     {
       end: 2384.28,
-
       start: 2381.56,
-      text: 'So I think we have high hopes for that market.',
+      text: "So I think we have high hopes for that market."
     },
     {
-      end: 2387.6800000000003,
-
+      end: 2387.68,
       start: 2384.28,
-      text: "It's not going to be a high ARPU market, but it's a large market.",
+      text: "It's not going to be a high ARPU market, but it's a large market."
     },
     {
       end: 2389.8,
-
-      start: 2387.6800000000003,
-      text: 'So we make it up to the quantity.',
+      start: 2387.68,
+      text: "So we make it up to the quantity."
     },
     {
-      end: 2398.1600000000003,
-
+      end: 2398.16,
       start: 2389.8,
-      text: "And then, overseas, the real issue is that most aircraft don't have an option today.",
+      text: "And then, overseas, the real issue is that most aircraft don't have an option today."
     },
     {
-      end: 2406.6800000000003,
-
-      start: 2398.1600000000003,
-      text: 'Of the 14,000 business aircraft outside the United States, about three-ish are heavy jets.',
+      end: 2406.68,
+      start: 2398.16,
+      text: "Of the 14,000 business aircraft outside the United States, about three-ish are heavy jets."
     },
     {
-      end: 2407.6800000000003,
-
-      start: 2406.6800000000003,
-      text: 'And they have an option.',
+      end: 2407.68,
+      start: 2406.68,
+      text: "And they have an option."
     },
     {
       end: 2416.88,
-
-      start: 2407.6800000000003,
-      text: 'They have a geostatilite option, and you know, about less than a third of those have that service today.',
+      start: 2407.68,
+      text: "They have a geostatilite option, and you know, about less than a third of those have that service today."
     },
     {
       end: 2418.56,
-
       start: 2416.88,
-      text: "And that's, I think, largely related to expense.",
+      text: "And that's, I think, largely related to expense."
     },
     {
       end: 2422.96,
-
       start: 2418.56,
-      text: "You know, it's very expensive to install and very high service costs.",
+      text: "You know, it's very expensive to install and very high service costs."
     },
     {
       end: 2428.6,
-
       start: 2422.96,
-      text: 'So in that part of the market, I think, cost will be an issue and sort of ease of install.',
+      text: "So in that part of the market, I think, cost will be an issue and sort of ease of install."
     },
     {
       end: 2432.12,
-
       start: 2428.6,
-      text: 'And I think RGBB product is well positioned for that.',
+      text: "And I think RGBB product is well positioned for that."
     },
     {
       end: 2438.68,
-
       start: 2432.12,
-      text: "And then, in the medium-sized jets on down, there's nothing overseas that they can really use.",
+      text: "And then, in the medium-sized jets on down, there's nothing overseas that they can really use."
     },
     {
       end: 2444.56,
-
       start: 2438.68,
-      text: "There's the EAN ATG network in Europe, but that's really not been sold to business aviation.",
+      text: "There's the EAN ATG network in Europe, but that's really not been sold to business aviation."
     },
     {
       end: 2449.4,
-
       start: 2444.56,
-      text: "And I think, I don't know all the reasons why they haven't done that, but they haven't.",
+      text: "And I think, I don't know all the reasons why they haven't done that, but they haven't."
     },
     {
       end: 2451.04,
-
       start: 2449.4,
-      text: "So there's really not much of an option.",
+      text: "So there's really not much of an option."
     },
     {
       end: 2461.6,
-
       start: 2451.04,
-      text: "And the good news about GBB is it's, you know, small form factor, and, you know, competitive pricing will enable people to fit GBB on all those aircraft.",
+      text: "And the good news about GBB is it's, you know, small form factor, and, you know, competitive pricing will enable people to fit GBB on all those aircraft."
     },
     {
       end: 2465.44,
-
       start: 2461.6,
-      text: "So we think that's going to be, you know, a great opportunity for us.",
+      text: "So we think that's going to be, you know, a great opportunity for us."
     },
     {
       end: 2466.44,
-
       start: 2465.44,
-      text: 'Great.',
+      text: "Great."
     },
     {
       end: 2468.92,
-
       start: 2466.44,
-      text: "That's very helpful to help people kind of frame it.",
+      text: "That's very helpful to help people kind of frame it."
     },
     {
       end: 2474.96,
-
       start: 2468.92,
-      text: 'And I think Jesse mentioned that GBB could be material in 2025.',
+      text: "And I think Jesse mentioned that GBB could be material in 2025."
     },
     {
       end: 2484.04,
-
       start: 2474.96,
-      text: "Is that kind of the hope, then, is that GBB opens up and unlocks that 14,000 global opportunity that haven't had the availability before?",
+      text: "Is that kind of the hope, then, is that GBB opens up and unlocks that 14,000 global opportunity that haven't had the availability before?"
     },
     {
       end: 2493.12,
-
       start: 2484.04,
-      text: "And that's why, and what does material kind of, can you give us a hint of what immaterial might mean in 25?",
+      text: "And that's why, and what does material kind of, can you give us a hint of what immaterial might mean in 25?"
     },
     {
       end: 2497.36,
-
       start: 2493.12,
-      text: "I am not in charge of the definition of material, so I'll let Jesse deal with that.",
+      text: "I am not in charge of the definition of material, so I'll let Jesse deal with that."
     },
     {
       end: 2509.56,
-
       start: 2497.36,
-      text: "You know, we're looking to commercially launch the GBB antenna and network in the fourth quarter of 2024.",
+      text: "You know, we're looking to commercially launch the GBB antenna and network in the fourth quarter of 2024."
     },
     {
       end: 2515.08,
-
       start: 2509.56,
-      text: 'So you can imagine installs starting to hit, you know, at the end of 2024 and going into 2025.',
+      text: "So you can imagine installs starting to hit, you know, at the end of 2024 and going into 2025."
     },
     {
       end: 2520.08,
-
       start: 2515.08,
-      text: "So that's, I think, why we say material, and we'll start getting service revenue, really, in 2025 on that.",
+      text: "So that's, I think, why we say material, and we'll start getting service revenue, really, in 2025 on that."
     },
     {
       end: 2521.08,
-
       start: 2520.08,
-      text: 'Yeah.',
+      text: "Yeah."
     },
     {
       end: 2522.08,
-
       start: 2521.08,
-      text: 'Yeah.',
+      text: "Yeah."
     },
     {
       end: 2523.08,
-
       start: 2522.08,
-      text: 'Okay.',
+      text: "Okay."
     },
     {
       end: 2527.6,
-
       start: 2523.08,
-      text: "So it's still going to be heavily weighted beyond the equipment side, but you'll start getting, you know, some service revenue.",
+      text: "So it's still going to be heavily weighted beyond the equipment side, but you'll start getting, you know, some service revenue."
     },
     {
       end: 2528.6,
-
       start: 2527.6,
-      text: 'Great.',
+      text: "Great."
     },
     {
       end: 2538.08,
-
       start: 2528.6,
-      text: 'Last one for me, and of course, you know, I love service revenue guidance rather than just total revenue guidance, because I do think the overall value of the company is going to be more driven by service than the one-time equipment revenue.',
+      text: "Last one for me, and of course, you know, I love service revenue guidance rather than just total revenue guidance, because I do think the overall value of the company is going to be more driven by service than the one-time equipment revenue."
     },
     {
-      end: 2541.3599999999997,
-
+      end: 2541.36,
       start: 2538.08,
-      text: 'But the final one, $100 million debt pay down.',
+      text: "But the final one, $100 million debt pay down."
     },
     {
       end: 2546.04,
-
-      start: 2541.3599999999997,
-      text: 'That sounds nice to get the debt reduced as the hedge kind of comes down, first step down.',
+      start: 2541.36,
+      text: "That sounds nice to get the debt reduced as the hedge kind of comes down, first step down."
     },
     {
       end: 2554.84,
-
       start: 2546.04,
-      text: 'How much cash do you think you need on hand to run the business, particularly as you look at maybe the working capital pressure with the FCC program?',
+      text: "How much cash do you think you need on hand to run the business, particularly as you look at maybe the working capital pressure with the FCC program?"
     },
     {
       end: 2559.52,
-
       start: 2554.84,
-      text: 'And then remind us of what the other step-downs on the hedge are as far as timing.',
+      text: "And then remind us of what the other step-downs on the hedge are as far as timing."
     },
     {
       end: 2560.52,
-
       start: 2559.52,
-      text: 'Yeah.',
+      text: "Yeah."
     },
     {
       end: 2572.08,
-
       start: 2560.52,
-      text: 'So, I mean, in terms of the cash that we would like to have on hand, as a reminder, we have the $100 million revolver available to us.',
+      text: "So, I mean, in terms of the cash that we would like to have on hand, as a reminder, we have the $100 million revolver available to us."
     },
     {
       end: 2594.36,
-
       start: 2572.08,
-      text: 'So we always have that, but, you know, somewhere between $50 million to $75 million, we like to be a little bit more conservative and making sure that we have that cash on hand, and especially, as you noted, with some inventory requirements with the FCC initially, until we get the reimbursements back from the government, so there could be a small lag in that initially.',
+      text: "So we always have that, but, you know, somewhere between $50 million to $75 million, we like to be a little bit more conservative and making sure that we have that cash on hand, and especially, as you noted, with some inventory requirements with the FCC initially, until we get the reimbursements back from the government, so there could be a small lag in that initially."
     },
     {
-      end: 2627.7599999999998,
-
+      end: 2627.76,
       start: 2594.36,
-      text: "And with regards to the hedge pay down, we've got the $125 million pay down that happens in July of this year, and then the next pay down is in December of 2024, so it goes from $525 down to $350, and then it'll step down to $250, in terms of what's hedged, it'll step down to $250 December of 2025, and then December of 2026 down to $200.",
+      text: "And with regards to the hedge pay down, we've got the $125 million pay down that happens in July of this year, and then the next pay down is in December of 2024, so it goes from $525 down to $350, and then it'll step down to $250, in terms of what's hedged, it'll step down to $250 December of 2025, and then December of 2026 down to $200."
     },
     {
-      end: 2628.7599999999998,
-
-      start: 2627.7599999999998,
-      text: 'Great.',
+      end: 2628.76,
+      start: 2627.76,
+      text: "Great."
     },
     {
-      end: 2629.7599999999998,
-
-      start: 2628.7599999999998,
-      text: 'That helps a lot.',
+      end: 2629.76,
+      start: 2628.76,
+      text: "That helps a lot."
     },
     {
-      end: 2630.7599999999998,
-
-      start: 2629.7599999999998,
-      text: 'All right.',
+      end: 2630.76,
+      start: 2629.76,
+      text: "All right."
     },
     {
-      end: 2631.7599999999998,
-
-      start: 2630.7599999999998,
-      text: 'Thanks, everybody.',
+      end: 2631.76,
+      start: 2630.76,
+      text: "Thanks, everybody."
     },
     {
-      end: 2632.7599999999998,
-
-      start: 2631.7599999999998,
-      text: 'Stay well.',
+      end: 2632.76,
+      start: 2631.76,
+      text: "Stay well."
     },
     {
-      end: 2633.7599999999998,
-
-      start: 2632.7599999999998,
-      text: 'Thanks, Rick.',
+      end: 2633.76,
+      start: 2632.76,
+      text: "Thanks, Rick."
     },
     {
-      end: 2634.7599999999998,
-
-      start: 2633.7599999999998,
-      text: 'Thanks, Rick.',
+      end: 2634.76,
+      start: 2633.76,
+      text: "Thanks, Rick."
     },
     {
       end: 2635.76,
-
-      start: 2634.7599999999998,
-      text: 'Thank you.',
+      start: 2634.76,
+      text: "Thank you."
     },
     {
       end: 2642.76,
-
       start: 2635.76,
-      text: 'And our next question comes from the line of Phil Cusick with JPMorgan.',
+      text: "And our next question comes from the line of Phil Cusick with JPMorgan."
     },
     {
       end: 2643.76,
-
       start: 2642.76,
-      text: 'Hi, guys.',
+      text: "Hi, guys."
     },
     {
       end: 2644.76,
-
       start: 2643.76,
-      text: 'Thanks.',
+      text: "Thanks."
     },
     {
-      end: 2660.5200000000004,
-
+      end: 2660.52,
       start: 2644.76,
-      text: "You know, just a couple of follow-ups on Rick's questions, and maybe talk about the long polls to launch the GBB network, any update on OneWeb's progress there, and what else has to happen for you to get that up and launched in 2024, what are the big pieces?",
+      text: "You know, just a couple of follow-ups on Rick's questions, and maybe talk about the long polls to launch the GBB network, any update on OneWeb's progress there, and what else has to happen for you to get that up and launched in 2024, what are the big pieces?"
     },
     {
       end: 2671.32,
-
-      start: 2660.5200000000004,
-      text: "And you talked about what the alternatives are today, but what are the alternatives that look like they're coming down the line, who else is working on products for global private aircraft?",
+      start: 2660.52,
+      text: "And you talked about what the alternatives are today, but what are the alternatives that look like they're coming down the line, who else is working on products for global private aircraft?"
     },
     {
       end: 2672.32,
-
       start: 2671.32,
-      text: 'Thanks.',
+      text: "Thanks."
     },
     {
       end: 2673.32,
-
       start: 2672.32,
-      text: 'Yeah.',
+      text: "Yeah."
     },
     {
       end: 2674.32,
-
       start: 2673.32,
-      text: 'Sure.',
+      text: "Sure."
     },
     {
-      end: 2676.6800000000003,
-
+      end: 2676.68,
       start: 2674.32,
-      text: "So there's two long polls.",
+      text: "So there's two long polls."
     },
     {
       end: 2678.44,
-
-      start: 2676.6800000000003,
-      text: 'One is the OneWeb network.',
+      start: 2676.68,
+      text: "One is the OneWeb network."
     },
     {
       end: 2683.96,
-
       start: 2678.44,
-      text: "They've launched now all the satellites they need to complete their global network.",
+      text: "They've launched now all the satellites they need to complete their global network."
     },
     {
-      end: 2688.2000000000003,
-
+      end: 2688.2,
       start: 2683.96,
-      text: 'They do have, I think, another two launches, but those are all spare satellites.',
+      text: "They do have, I think, another two launches, but those are all spare satellites."
     },
     {
       end: 2693.16,
-
-      start: 2688.2000000000003,
-      text: 'So what they need to provide our service is actually in space.',
+      start: 2688.2,
+      text: "So what they need to provide our service is actually in space."
     },
     {
       end: 2699.72,
-
       start: 2693.16,
-      text: 'They need to position those satellites now in their orbital planes and get them up and rock operational.',
+      text: "They need to position those satellites now in their orbital planes and get them up and rock operational."
     },
     {
-      end: 2704.7599999999998,
-
+      end: 2704.76,
       start: 2699.72,
-      text: "I think that they will, and there's some software changes they make for Aero.",
+      text: "I think that they will, and there's some software changes they make for Aero."
     },
     {
       end: 2721.4,
-
-      start: 2704.7599999999998,
-      text: "So that will all get done, I think, by the middle of next year, and I think that will be a slightly shorter poll than the other one, which is our building of our terminal, our aircraft terminal, which we're doing with Hughes.",
+      start: 2704.76,
+      text: "So that will all get done, I think, by the middle of next year, and I think that will be a slightly shorter poll than the other one, which is our building of our terminal, our aircraft terminal, which we're doing with Hughes."
     },
     {
       end: 2727.8,
-
       start: 2721.4,
-      text: 'That program is in great shape, and I have to say, working with Hughes is a real pleasure.',
+      text: "That program is in great shape, and I have to say, working with Hughes is a real pleasure."
     },
     {
       end: 2736.44,
-
       start: 2727.8,
-      text: "Their operational maturity and program maturity is outstanding, and so we've been able to actually move that project in.",
+      text: "Their operational maturity and program maturity is outstanding, and so we've been able to actually move that project in."
     },
     {
-      end: 2741.2000000000003,
-
+      end: 2741.2,
       start: 2736.44,
-      text: "It was going to be an early 25 delivery, and now we're into the fourth quarter of 24.",
+      text: "It was going to be an early 25 delivery, and now we're into the fourth quarter of 24."
     },
     {
       end: 2746.84,
-
-      start: 2741.2000000000003,
-      text: "It's moved to the last, and I think we see, frankly, some opportunity perhaps to even move it in a little more.",
+      start: 2741.2,
+      text: "It's moved to the last, and I think we see, frankly, some opportunity perhaps to even move it in a little more."
     },
     {
       end: 2750.52,
-
       start: 2746.84,
-      text: "So that's going extremely well.",
+      text: "So that's going extremely well."
     },
     {
       end: 2761.52,
-
       start: 2750.52,
-      text: "I'm not going to give away any secrets, but we're going to have some fun news about that at eBay's in Geneva at the end of May, the big global business aviation convention.",
+      text: "I'm not going to give away any secrets, but we're going to have some fun news about that at eBay's in Geneva at the end of May, the big global business aviation convention."
     },
     {
       end: 2767,
-
       start: 2761.52,
-      text: 'So those are really the two polls, and I think both are in very good shape at the moment.',
+      text: "So those are really the two polls, and I think both are in very good shape at the moment."
     },
     {
       end: 2777.24,
-
       start: 2767,
-      text: 'In terms of alternatives right now, I think Starlink would be the main one.',
+      text: "In terms of alternatives right now, I think Starlink would be the main one."
     },
     {
       end: 2789.16,
-
       start: 2777.24,
-      text: 'They have a large antenna today, 39 inches long, 31 inches wide, which is quite large for business aviation.',
+      text: "They have a large antenna today, 39 inches long, 31 inches wide, which is quite large for business aviation."
     },
     {
       end: 2803.12,
-
       start: 2789.16,
-      text: "That's installed on some Embraer 145, so it's flying for JSX airlines, and on some G650s, which I believe are all pretty much owned by some Muskundity or another.",
+      text: "That's installed on some Embraer 145, so it's flying for JSX airlines, and on some G650s, which I believe are all pretty much owned by some Muskundity or another."
     },
     {
       end: 2814.6,
-
       start: 2803.12,
-      text: "They've been seemingly having difficulty getting STCs for that, and they're sort of making halting progress trying to get into the market.",
+      text: "They've been seemingly having difficulty getting STCs for that, and they're sort of making halting progress trying to get into the market."
     },
     {
       end: 2821.16,
-
       start: 2814.6,
-      text: 'From personally, I think that we have great respect for Starlink and the people at SpaceX.',
+      text: "From personally, I think that we have great respect for Starlink and the people at SpaceX."
     },
     {
       end: 2847.88,
-
       start: 2821.16,
-      text: "They're literally a group of rocket scientists, but we think that we'll be very competitive with them in our market, and with our combination of ATG and LEO, frankly, we think we're going to have the best product on the market when it comes to return link will be much better than they are, and other factors I won't bore you with in terms of the geeky stuff, but we think we'll have a very competitive product.",
+      text: "They're literally a group of rocket scientists, but we think that we'll be very competitive with them in our market, and with our combination of ATG and LEO, frankly, we think we're going to have the best product on the market when it comes to return link will be much better than they are, and other factors I won't bore you with in terms of the geeky stuff, but we think we'll have a very competitive product."
     },
     {
       end: 2857.32,
-
       start: 2847.88,
-      text: "We'll have much better service in a market that is very complex and very service-sensitive and very demanding of service, so that's good.",
+      text: "We'll have much better service in a market that is very complex and very service-sensitive and very demanding of service, so that's good."
     },
     {
       end: 2864.28,
-
       start: 2857.32,
-      text: "And I think that on pricing, we'll be very competitive, so we think we can compete effectively with them.",
+      text: "And I think that on pricing, we'll be very competitive, so we think we can compete effectively with them."
     },
     {
       end: 2871.56,
-
       start: 2864.28,
-      text: "I guess the third point I'd make is coming into this market makes no sense for them.",
+      text: "I guess the third point I'd make is coming into this market makes no sense for them."
     },
     {
-      end: 2873.6400000000003,
-
+      end: 2873.64,
       start: 2871.56,
-      text: "They're a great company.",
+      text: "They're a great company."
     },
     {
       end: 2882.6,
-
-      start: 2873.6400000000003,
-      text: 'They do some things extremely well, obviously, on the satellite side, but when it comes to markets, they generally do it two ways.',
+      start: 2873.64,
+      text: "They do some things extremely well, obviously, on the satellite side, but when it comes to markets, they generally do it two ways."
     },
     {
       end: 2914.8,
-
       start: 2882.6,
-      text: "One, they have a very standardized offering after going after very large markets, like direct-to-home, and it's relatively simple on the service side, and the Musk marketing aura is enough to sell that product, and so that works well for them, and they do it at real scale, and they get costs way, way down, but they have to manufacture millions of terminals and the like to actually have the cost come down to where they need it.",
+      text: "One, they have a very standardized offering after going after very large markets, like direct-to-home, and it's relatively simple on the service side, and the Musk marketing aura is enough to sell that product, and so that works well for them, and they do it at real scale, and they get costs way, way down, but they have to manufacture millions of terminals and the like to actually have the cost come down to where they need it."
     },
     {
       end: 2930.92,
-
       start: 2914.8,
-      text: "The other thing they do really well is really large customized programs, like for the Department of Defense and the like, and their deals are worth millions, and it's worth them committing huge teams of geniuses to build those programs and deliver them.",
+      text: "The other thing they do really well is really large customized programs, like for the Department of Defense and the like, and their deals are worth millions, and it's worth them committing huge teams of geniuses to build those programs and deliver them."
     },
     {
-      end: 2943.2400000000002,
-
+      end: 2943.24,
       start: 2930.92,
-      text: "But what doesn't really make sense is getting into markets that are very small and require lots of customization and cost, and I'm not sure they're really good at that.",
+      text: "But what doesn't really make sense is getting into markets that are very small and require lots of customization and cost, and I'm not sure they're really good at that."
     },
     {
       end: 2950.92,
-
-      start: 2943.2400000000002,
-      text: "When it comes to the antenna, they're trying to take a consumer-grade antenna and beef it up for Aero.",
+      start: 2943.24,
+      text: "When it comes to the antenna, they're trying to take a consumer-grade antenna and beef it up for Aero."
     },
     {
-      end: 2952.7200000000003,
-
+      end: 2952.72,
       start: 2950.92,
-      text: "That doesn't really work in Aero.",
+      text: "That doesn't really work in Aero."
     },
     {
       end: 2966.28,
-
-      start: 2952.7200000000003,
-      text: "It's got to be a ruggedized, Aero-standard-manufactured piece of equipment, which is a lot different than what you can put on a home, because the same with routers, the same with every single component of what they have.",
+      start: 2952.72,
+      text: "It's got to be a ruggedized, Aero-standard-manufactured piece of equipment, which is a lot different than what you can put on a home, because the same with routers, the same with every single component of what they have."
     },
     {
-      end: 2973.0400000000004,
-
+      end: 2973.04,
       start: 2966.28,
-      text: "The level of customization for a very small number of units doesn't make sense.",
+      text: "The level of customization for a very small number of units doesn't make sense."
     },
     {
       end: 2980.32,
-
-      start: 2973.0400000000004,
-      text: "The level of service that you have to have for a very small number of units doesn't really make sense either.",
+      start: 2973.04,
+      text: "The level of service that you have to have for a very small number of units doesn't really make sense either."
     },
     {
       end: 2991.4,
-
       start: 2980.32,
-      text: "So I think if they come in and they dramatically cut pricing, they're going to take a $300 or $400 million service market today and make it a $150 million service revenue market.",
+      text: "So I think if they come in and they dramatically cut pricing, they're going to take a $300 or $400 million service market today and make it a $150 million service revenue market."
     },
     {
       end: 2996.2,
-
       start: 2991.4,
-      text: "That doesn't really make sense, because that's a rounding error in their numbers.",
+      text: "That doesn't really make sense, because that's a rounding error in their numbers."
     },
     {
       end: 3000.16,
-
       start: 2996.2,
-      text: "So anyhow, that's our take on them.",
+      text: "So anyhow, that's our take on them."
     },
     {
       end: 3009.96,
-
       start: 3000.16,
-      text: 'And then I think Satcom Direct has a deal with OneWeb as well as we do.',
+      text: "And then I think Satcom Direct has a deal with OneWeb as well as we do."
     },
     {
       end: 3012.24,
-
       start: 3009.96,
-      text: "We don't see a lot of progress from them on that front.",
+      text: "We don't see a lot of progress from them on that front."
     },
     {
-      end: 3017.7599999999998,
-
+      end: 3017.76,
       start: 3012.24,
-      text: 'They seem to be pushing some of their other products more heavily, but I think we always have to take them seriously.',
+      text: "They seem to be pushing some of their other products more heavily, but I think we always have to take them seriously."
     },
     {
-      end: 3018.7599999999998,
-
-      start: 3017.7599999999998,
-      text: "They're a good competitor.",
+      end: 3018.76,
+      start: 3017.76,
+      text: "They're a good competitor."
     },
     {
-      end: 3021.7599999999998,
-
-      start: 3018.7599999999998,
-      text: "So I think that's kind of the competitive landscape.",
+      end: 3021.76,
+      start: 3018.76,
+      text: "So I think that's kind of the competitive landscape."
     },
     {
-      end: 3022.7599999999998,
-
-      start: 3021.7599999999998,
-      text: "That's helpful.",
+      end: 3022.76,
+      start: 3021.76,
+      text: "That's helpful."
     },
     {
       end: 3023.76,
-
-      start: 3022.7599999999998,
-      text: 'Thanks, Oka.',
+      start: 3022.76,
+      text: "Thanks, Oka."
     },
     {
       end: 3026.44,
-
       start: 3023.76,
-      text: 'Thank you.',
+      text: "Thank you."
     },
     {
       end: 3035.88,
-
       start: 3026.44,
-      text: 'And our next question comes from the line of Landon Park with Morgan Stanley.',
+      text: "And our next question comes from the line of Landon Park with Morgan Stanley."
     },
     {
       end: 3036.88,
-
       start: 3035.88,
-      text: 'Great.',
+      text: "Great."
     },
     {
       end: 3037.88,
-
       start: 3036.88,
-      text: 'Good morning, everyone.',
+      text: "Good morning, everyone."
     },
     {
       end: 3038.88,
-
       start: 3037.88,
-      text: 'Thanks for taking the questions.',
+      text: "Thanks for taking the questions."
     },
     {
       end: 3043.88,
-
       start: 3038.88,
-      text: 'I was wondering if we could start on the OEM side.',
+      text: "I was wondering if we could start on the OEM side."
     },
     {
       end: 3066,
-
       start: 3043.88,
-      text: "I'm wondering if maybe you could comment on what kind of pay grade you guys have been seeing out of that channel and maybe how that's trended over the last couple years and any early indications you've had from them regarding GBB, just what the outlook looks like there.",
+      text: "I'm wondering if maybe you could comment on what kind of pay grade you guys have been seeing out of that channel and maybe how that's trended over the last couple years and any early indications you've had from them regarding GBB, just what the outlook looks like there."
     },
     {
       end: 3077.96,
-
       start: 3066,
-      text: 'And then separately, I was just wondering if you could talk about what the EBITDA cadence might look like through the year, given that the 1Q level was already at the high end of your guidance.',
+      text: "And then separately, I was just wondering if you could talk about what the EBITDA cadence might look like through the year, given that the 1Q level was already at the high end of your guidance."
     },
     {
       end: 3080.48,
-
       start: 3077.96,
-      text: 'It seemed to include some on-time expenses.',
+      text: "It seemed to include some on-time expenses."
     },
     {
       end: 3085.2,
-
       start: 3080.48,
-      text: 'So how should we think about the percentage through the rest of the year there?',
+      text: "So how should we think about the percentage through the rest of the year there?"
     },
     {
       end: 3086.2,
-
       start: 3085.2,
-      text: 'Sure.',
+      text: "Sure."
     },
     {
       end: 3094.52,
-
       start: 3086.2,
-      text: "So I'll take the OEM part and leave Jesse with the hard numbers part on EBITDA.",
+      text: "So I'll take the OEM part and leave Jesse with the hard numbers part on EBITDA."
     },
     {
       end: 3099.72,
-
       start: 3094.52,
-      text: 'Our take rates are very widely by OEM, I would say.',
+      text: "Our take rates are very widely by OEM, I would say."
     },
     {
       end: 3117,
-
       start: 3099.72,
-      text: 'We have very high take rates at the Textrons and OEMs and Embraers today, less so at Gulf Stream coming out of Line 5, for instance, but we often get put in in the aftermarket there, same at Bombardier.',
+      text: "We have very high take rates at the Textrons and OEMs and Embraers today, less so at Gulf Stream coming out of Line 5, for instance, but we often get put in in the aftermarket there, same at Bombardier."
     },
     {
       end: 3128.72,
-
       start: 3117,
-      text: "So it's a little hard to say exactly what the take rate is because often we're installed sort of just after it comes off the line in a service center or something like that.",
+      text: "So it's a little hard to say exactly what the take rate is because often we're installed sort of just after it comes off the line in a service center or something like that."
     },
     {
-      end: 3142.8799999999997,
-
+      end: 3142.88,
       start: 3128.72,
-      text: 'However, I think that the way to think about it, about 65% of OEM deliveries stay in the United States, something like that.',
+      text: "However, I think that the way to think about it, about 65% of OEM deliveries stay in the United States, something like that."
     },
     {
-      end: 3148.4399999999996,
-
-      start: 3142.8799999999997,
-      text: "And so we're kind of limited to that side of the opportunity, if you will.",
+      end: 3148.44,
+      start: 3142.88,
+      text: "And so we're kind of limited to that side of the opportunity, if you will."
     },
     {
       end: 3165.24,
-
-      start: 3148.4399999999996,
-      text: 'And we would be on almost all Textron planes delivered to that market, very high percentage of Embraers, you know, and then less so, like I just said, on the Gulf Streams and Bombardiers and DeSos.',
+      start: 3148.44,
+      text: "And we would be on almost all Textron planes delivered to that market, very high percentage of Embraers, you know, and then less so, like I just said, on the Gulf Streams and Bombardiers and DeSos."
     },
     {
       end: 3175.28,
-
       start: 3165.24,
-      text: 'However, we have very high penetration of the Bombardier Gulf Streams and DeSos, but again, that generally comes in in the aftermarket.',
+      text: "However, we have very high penetration of the Bombardier Gulf Streams and DeSos, but again, that generally comes in in the aftermarket."
     },
     {
       end: 3181.12,
-
       start: 3175.28,
-      text: 'I would say our take rates have been growing, which is good.',
+      text: "I would say our take rates have been growing, which is good."
     },
     {
       end: 3194,
-
       start: 3181.12,
-      text: "And then I would say that on GBB, the receptivity is just outstanding, and I've never seen the OEMs as excited as I see them now about that product.",
+      text: "And then I would say that on GBB, the receptivity is just outstanding, and I've never seen the OEMs as excited as I see them now about that product."
     },
     {
       end: 3219.4,
-
       start: 3194,
-      text: 'And in terms of the EBITDA for the rest of the year, so definitely the revenue is going to be higher on the second half of the year than the first half as we talk through, but we will have some increase in expenses, so in Q1, the GBB expenses was only $1.5 million and 5G expenses was only $0.4 million.',
+      text: "And in terms of the EBITDA for the rest of the year, so definitely the revenue is going to be higher on the second half of the year than the first half as we talk through, but we will have some increase in expenses, so in Q1, the GBB expenses was only $1.5 million and 5G expenses was only $0.4 million."
     },
     {
-      end: 3228.1600000000003,
-
+      end: 3228.16,
       start: 3219.4,
-      text: 'So both for 5G and GBB, those expenses are going to be picking up, as well as the other operational initiative expenses.',
+      text: "So both for 5G and GBB, those expenses are going to be picking up, as well as the other operational initiative expenses."
     },
     {
       end: 3233.52,
-
-      start: 3228.1600000000003,
-      text: 'So that will have, you know, some impact on the EBITDA going forward while the revenue is growing.',
+      start: 3228.16,
+      text: "So that will have, you know, some impact on the EBITDA going forward while the revenue is growing."
     },
     {
       end: 3234.52,
-
       start: 3233.52,
-      text: 'Understood.',
+      text: "Understood."
     },
     {
       end: 3235.52,
-
       start: 3234.52,
-      text: "That's very helpful.",
+      text: "That's very helpful."
     },
     {
       end: 3257,
-
       start: 3235.52,
-      text: 'And then just to follow up on the OEM side, maybe just including the aftermarket installs that come shortly after delivery, of those 700 with the 65% in the U.S., is it nearing 90-plus percent in terms of what you guys can get off of that?',
+      text: "And then just to follow up on the OEM side, maybe just including the aftermarket installs that come shortly after delivery, of those 700 with the 65% in the U.S., is it nearing 90-plus percent in terms of what you guys can get off of that?"
     },
     {
-      end: 3270.7599999999998,
-
+      end: 3270.76,
       start: 3257,
-      text: 'And just maybe more broadly, are you seeing anything on the macro side, have you picked up any customer sensitivity or anything along those lines?',
+      text: "And just maybe more broadly, are you seeing anything on the macro side, have you picked up any customer sensitivity or anything along those lines?"
     },
     {
-      end: 3274.2799999999997,
-
-      start: 3270.7599999999998,
-      text: "We haven't shared, you know, the attachment rates at the OEMs.",
+      end: 3274.28,
+      start: 3270.76,
+      text: "We haven't shared, you know, the attachment rates at the OEMs."
     },
     {
       end: 3276.52,
-
-      start: 3274.2799999999997,
-      text: 'We can contemplate sharing those in the future.',
+      start: 3274.28,
+      text: "We can contemplate sharing those in the future."
     },
     {
       end: 3277.52,
-
       start: 3276.52,
-      text: 'Okay.',
+      text: "Okay."
     },
     {
       end: 3287.44,
-
       start: 3277.52,
-      text: "So I'm not going to give you exact numbers, but like I said, if you, first of all, right today, we are limited to those that are being delivered in the U.S.",
+      text: "So I'm not going to give you exact numbers, but like I said, if you, first of all, right today, we are limited to those that are being delivered in the U.S."
     },
     {
       end: 3301.24,
-
       start: 3287.44,
-      text: "I'm going to give you a little wrinkle, which is sometimes those that are ordered overseas do install our equipment, but they don't activate it, and they install it in order to get better pricing in the aftermarket when they go to sell that air.",
+      text: "I'm going to give you a little wrinkle, which is sometimes those that are ordered overseas do install our equipment, but they don't activate it, and they install it in order to get better pricing in the aftermarket when they go to sell that air."
     },
     {
       end: 3304.08,
-
       start: 3301.24,
-      text: 'So they think they have our product in and it will sell better.',
+      text: "So they think they have our product in and it will sell better."
     },
     {
       end: 3308.4,
-
       start: 3304.08,
-      text: "So there's a little bit of a wrinkle there.",
+      text: "So there's a little bit of a wrinkle there."
     },
     {
       end: 3317.6,
-
       start: 3308.4,
-      text: "But I think, you know, that if you look at Textron deliveries in the U.S., we're probably close to 90%, something like that.",
+      text: "But I think, you know, that if you look at Textron deliveries in the U.S., we're probably close to 90%, something like that."
     },
     {
       end: 3338.08,
-
       start: 3317.6,
-      text: "You know, if you look at Goldstream, you know, it's going to be at the other end, it's going to be sort of 20%, and so then, you know, and because we, you know, you know, it's sometimes in the aftermarket, at least if it's a relatively new Goldstream, it's going to be at a Goldstream aftermarket facility generally, you know.",
+      text: "You know, if you look at Goldstream, you know, it's going to be at the other end, it's going to be sort of 20%, and so then, you know, and because we, you know, you know, it's sometimes in the aftermarket, at least if it's a relatively new Goldstream, it's going to be at a Goldstream aftermarket facility generally, you know."
     },
     {
-      end: 3343.4399999999996,
-
+      end: 3343.44,
       start: 3338.08,
-      text: "We don't look at that, I would say, as a line fit OEM install.",
+      text: "We don't look at that, I would say, as a line fit OEM install."
     },
     {
-      end: 3346.3999999999996,
-
-      start: 3343.4399999999996,
-      text: "So we don't really count it that way.",
+      end: 3346.4,
+      start: 3343.44,
+      text: "So we don't really count it that way."
     },
     {
       end: 3349.56,
-
-      start: 3346.3999999999996,
-      text: "So let us contemplate whether we'll share that in the future landing, but I think I've",
+      start: 3346.4,
+      text: "So let us contemplate whether we'll share that in the future landing, but I think I've"
     },
     {
       end: 3353,
-
       start: 3349.56,
-      text: "given you the call. That's very helpful.",
+      text: "given you the call. That's very helpful."
     },
     {
       end: 3356.96,
-
       start: 3353,
-      text: 'Is there anything on the macro that you would know?',
+      text: "Is there anything on the macro that you would know?"
     },
     {
       end: 3359.24,
-
       start: 3356.96,
-      text: 'When you say macro, you mean macro economy?',
+      text: "When you say macro, you mean macro economy?"
     },
     {
       end: 3360.68,
-
       start: 3359.24,
-      text: 'Yeah, the macro.',
+      text: "Yeah, the macro."
     },
     {
       end: 3363.56,
-
       start: 3360.68,
-      text: "How it impacts people's feelings, you know.",
+      text: "How it impacts people's feelings, you know."
     },
     {
       end: 3367.08,
-
       start: 3363.56,
-      text: "Well, you know, it's on people's minds.",
+      text: "Well, you know, it's on people's minds."
     },
     {
       end: 3374.84,
-
       start: 3367.08,
-      text: 'We did a little poll of our dealer advisory council and some rogue shows to visit dealers.',
+      text: "We did a little poll of our dealer advisory council and some rogue shows to visit dealers."
     },
     {
-      end: 3381.7200000000003,
-
+      end: 3381.72,
       start: 3374.84,
-      text: "And so in all, I would say, let's call that 12 to 15 dealers, only one mentioned the economy being the issue.",
+      text: "And so in all, I would say, let's call that 12 to 15 dealers, only one mentioned the economy being the issue."
     },
     {
       end: 3393.52,
-
-      start: 3381.7200000000003,
-      text: "There are a lot of other things that got mentioned that, you know, might be, might ultimately be economic, but we're more, you know, I would say micro in reality.",
+      start: 3381.72,
+      text: "There are a lot of other things that got mentioned that, you know, might be, might ultimately be economic, but we're more, you know, I would say micro in reality."
     },
     {
       end: 3399.92,
-
       start: 3393.52,
-      text: "So, you know, there's been no real impact on orders at the OEMs, right, Will?",
+      text: "So, you know, there's been no real impact on orders at the OEMs, right, Will?"
     },
     {
       end: 3402.92,
-
       start: 3399.92,
-      text: 'I mean, they continue to be strong.',
+      text: "I mean, they continue to be strong."
     },
     {
       end: 3410.76,
-
       start: 3402.92,
-      text: "And from the dealer perspective, they're busier than they can really handle right now, cashing up on maintenance from COVID times.",
+      text: "And from the dealer perspective, they're busier than they can really handle right now, cashing up on maintenance from COVID times."
     },
     {
       end: 3419.4,
-
       start: 3410.76,
-      text: "I mean, they're literally planes parked on tarmacs that can't fly because they're no longer in compliance on their maintenance logs.",
+      text: "I mean, they're literally planes parked on tarmacs that can't fly because they're no longer in compliance on their maintenance logs."
     },
     {
       end: 3426.32,
-
       start: 3419.4,
-      text: "And, you know, they're trying to get that work done so those planes can start flying again.",
+      text: "And, you know, they're trying to get that work done so those planes can start flying again."
     },
     {
       end: 3429.2,
-
       start: 3426.32,
-      text: "So, you know, everybody's very, very busy.",
+      text: "So, you know, everybody's very, very busy."
     },
     {
-      end: 3433.8799999999997,
-
+      end: 3433.88,
       start: 3429.2,
-      text: "So I don't think, you know, the macro economy has really hurt the market.",
+      text: "So I don't think, you know, the macro economy has really hurt the market."
     },
     {
-      end: 3434.8799999999997,
-
-      start: 3433.8799999999997,
-      text: 'Great.',
+      end: 3434.88,
+      start: 3433.88,
+      text: "Great."
     },
     {
       end: 3439.08,
-
-      start: 3434.8799999999997,
-      text: 'Thanks so much for taking my questions.',
+      start: 3434.88,
+      text: "Thanks so much for taking my questions."
     },
     {
-      end: 3442.4399999999996,
-
+      end: 3442.44,
       start: 3439.08,
-      text: 'Thanks, Landon.',
+      text: "Thanks, Landon."
     },
     {
-      end: 3443.4399999999996,
-
-      start: 3442.4399999999996,
-      text: 'Thank you.',
+      end: 3443.44,
+      start: 3442.44,
+      text: "Thank you."
     },
     {
       end: 3450.16,
-
-      start: 3443.4399999999996,
-      text: 'Our next question comes from the line of Lance Vitanza with PD Cowan.',
+      start: 3443.44,
+      text: "Our next question comes from the line of Lance Vitanza with PD Cowan."
     },
     {
       end: 3453.72,
-
       start: 3450.16,
-      text: 'Thanks guys for taking the question.',
+      text: "Thanks guys for taking the question."
     },
     {
       end: 3472.56,
-
       start: 3453.72,
-      text: 'And maybe just to stay with the theme of the dealers and the shipments and activations and the turbulence there, I think, you know, the concern is that it does raise the specter of perhaps the macro pressures are kind of leading into the business jet demand.',
+      text: "And maybe just to stay with the theme of the dealers and the shipments and activations and the turbulence there, I think, you know, the concern is that it does raise the specter of perhaps the macro pressures are kind of leading into the business jet demand."
     },
     {
       end: 3481.12,
-
       start: 3472.56,
-      text: 'But just to be clear, it sounds like really what happened is that the dealers requested a lot of shipments historically because the lead times have become concerning.',
+      text: "But just to be clear, it sounds like really what happened is that the dealers requested a lot of shipments historically because the lead times have become concerning."
     },
     {
       end: 3482.64,
-
       start: 3481.12,
-      text: "And now that's reversing.",
+      text: "And now that's reversing."
     },
     {
       end: 3488.04,
-
       start: 3482.64,
-      text: "And it doesn't sound like the underlying kind of final demand has changed much.",
+      text: "And it doesn't sound like the underlying kind of final demand has changed much."
     },
     {
       end: 3489.12,
-
       start: 3488.04,
-      text: 'Is that fair?',
+      text: "Is that fair?"
     },
     {
       end: 3500.68,
-
       start: 3489.12,
-      text: "And I think you said, if anything, it's stronger than pre-COVID and presumably it's also stronger than where it was before the supply chain sort of got challenging.",
+      text: "And I think you said, if anything, it's stronger than pre-COVID and presumably it's also stronger than where it was before the supply chain sort of got challenging."
     },
     {
       end: 3501.68,
-
       start: 3500.68,
-      text: 'Is that fair?',
+      text: "Is that fair?"
     },
     {
       end: 3504.44,
-
       start: 3501.68,
-      text: "Yeah, I think that's all fair.",
+      text: "Yeah, I think that's all fair."
     },
     {
       end: 3512.16,
-
       start: 3504.44,
-      text: 'You know, we had a huge Q3 and Q4 shipments, you know, record breaking.',
+      text: "You know, we had a huge Q3 and Q4 shipments, you know, record breaking."
     },
     {
       end: 3517.68,
-
       start: 3512.16,
-      text: 'Some of that, I think, was driven by the still COVID ordering patterns.',
+      text: "Some of that, I think, was driven by the still COVID ordering patterns."
     },
     {
       end: 3521.14,
-
       start: 3517.68,
-      text: 'I think also, you know, our equipment prices go up every January 1st.',
+      text: "I think also, you know, our equipment prices go up every January 1st."
     },
     {
-      end: 3527.9199999999996,
-
+      end: 3527.92,
       start: 3521.14,
-      text: 'So I think people were loading up ahead of time on equipment before the price increases kicked in.',
+      text: "So I think people were loading up ahead of time on equipment before the price increases kicked in."
     },
     {
       end: 3533.04,
-
-      start: 3527.9199999999996,
-      text: 'So, and I think that they bought, you know, enough inventory to last them well into this year.',
+      start: 3527.92,
+      text: "So, and I think that they bought, you know, enough inventory to last them well into this year."
     },
     {
       end: 3542.96,
-
       start: 3533.04,
-      text: "And, you know, they don't need to backfill, you know, but they're taking off the shelf to install if they've got already got plenty of inventory on the shelf.",
+      text: "And, you know, they don't need to backfill, you know, but they're taking off the shelf to install if they've got already got plenty of inventory on the shelf."
     },
     {
       end: 3545.88,
-
       start: 3542.96,
-      text: "So I think that's the real impact right now.",
+      text: "So I think that's the real impact right now."
     },
     {
       end: 3556.36,
-
       start: 3545.88,
-      text: "The important thing to us is getting the gear on the plane and activated and producing service revenue because, as Rick pointed out earlier, that's the real golden egg here.",
+      text: "The important thing to us is getting the gear on the plane and activated and producing service revenue because, as Rick pointed out earlier, that's the real golden egg here."
     },
     {
       end: 3561.88,
-
       start: 3556.36,
-      text: "So we're happy with that and, you know, a little inside baseball.",
+      text: "So we're happy with that and, you know, a little inside baseball."
     },
     {
       end: 3565.92,
-
       start: 3561.88,
-      text: 'We had a really good activation quarter.',
+      text: "We had a really good activation quarter."
     },
     {
       end: 3581.92,
-
       start: 3565.92,
-      text: "It doesn't show so much in AOL because when people go into maintenance or they put the aircraft up for sale, you know, they often almost always suspend the service for a couple months or however long it takes to sell the jet.",
+      text: "It doesn't show so much in AOL because when people go into maintenance or they put the aircraft up for sale, you know, they often almost always suspend the service for a couple months or however long it takes to sell the jet."
     },
     {
       end: 3592.48,
-
       start: 3581.92,
-      text: "So there's a little dampening there because those sale activities have picked up in the last year and the maintenance activities are picking up.",
+      text: "So there's a little dampening there because those sale activities have picked up in the last year and the maintenance activities are picking up."
     },
     {
       end: 3593.84,
-
       start: 3592.48,
-      text: "But that's all temporary, right?",
+      text: "But that's all temporary, right?"
     },
     {
-      end: 3604.8799999999997,
-
+      end: 3604.88,
       start: 3593.84,
-      text: 'Most of those, the ones that go for sale almost all come back online often with an upgrade, which we like, and the ones that go into the shop, they turn it back on as they come out of the shop.',
+      text: "Most of those, the ones that go for sale almost all come back online often with an upgrade, which we like, and the ones that go into the shop, they turn it back on as they come out of the shop."
     },
     {
-      end: 3614.3199999999997,
-
-      start: 3604.8799999999997,
-      text: "And obviously, if they're grounded waiting to get in the shop, they're really going to turn it off because they don't want to sit there paying megabits they're not using.",
+      end: 3614.32,
+      start: 3604.88,
+      text: "And obviously, if they're grounded waiting to get in the shop, they're really going to turn it off because they don't want to sit there paying megabits they're not using."
     },
     {
-      end: 3621.8799999999997,
-
-      start: 3614.3199999999997,
-      text: 'So those tend to dampen AOL, but we had good demand on the install side and activation side.',
+      end: 3621.88,
+      start: 3614.32,
+      text: "So those tend to dampen AOL, but we had good demand on the install side and activation side."
     },
     {
       end: 3624.92,
-
-      start: 3621.8799999999997,
-      text: 'And so we feel pretty good about that.',
+      start: 3621.88,
+      text: "And so we feel pretty good about that."
     },
     {
       end: 3630.84,
-
       start: 3624.92,
-      text: "The issue we found a couple of times is, you know, this plane's meant to come in for two months.",
+      text: "The issue we found a couple of times is, you know, this plane's meant to come in for two months."
     },
     {
       end: 3637.92,
-
       start: 3630.84,
-      text: "It's going to get all the following things done and the dealer would be like, I want to sell them an IFC system.",
+      text: "It's going to get all the following things done and the dealer would be like, I want to sell them an IFC system."
     },
     {
-      end: 3649.2000000000003,
-
+      end: 3649.2,
       start: 3637.92,
-      text: "However, if I do, because of my labor issues, I got to add two weeks to the two months and the customer won't accept that extension, you know, to the maintenance window.",
+      text: "However, if I do, because of my labor issues, I got to add two weeks to the two months and the customer won't accept that extension, you know, to the maintenance window."
     },
     {
       end: 3652.32,
-
-      start: 3649.2000000000003,
-      text: 'So those are the types of things that do dampen things a little bit.',
+      start: 3649.2,
+      text: "So those are the types of things that do dampen things a little bit."
     },
     {
       end: 3660.28,
-
       start: 3652.32,
-      text: 'But like I said, it was our second best activation month ever, quarter ever, and certainly our best first quarter activation.',
+      text: "But like I said, it was our second best activation month ever, quarter ever, and certainly our best first quarter activation."
     },
     {
       end: 3661.28,
-
       start: 3660.28,
-      text: 'Great.',
+      text: "Great."
     },
     {
       end: 3662.28,
-
       start: 3661.28,
-      text: 'Thanks.',
+      text: "Thanks."
     },
     {
       end: 3663.28,
-
       start: 3662.28,
-      text: 'Thanks, Oak.',
+      text: "Thanks, Oak."
     },
     {
       end: 3664.28,
-
       start: 3663.28,
-      text: 'Appreciate it.',
+      text: "Appreciate it."
     },
     {
       end: 3665.28,
-
       start: 3664.28,
-      text: 'Thank you.',
+      text: "Thank you."
     },
     {
       end: 3674.88,
-
       start: 3665.28,
-      text: 'And our next question comes from the line of Louis DePalma with William Blair.',
+      text: "And our next question comes from the line of Louis DePalma with William Blair."
     },
     {
       end: 3676.88,
-
       start: 3674.88,
-      text: 'Hey, Louis.',
+      text: "Hey, Louis."
     },
     {
-      end: 3684.2400000000002,
-
+      end: 3684.24,
       start: 3676.88,
-      text: 'Oak, Jesse and Will, good morning, and Jesse, congrats on your first call as CFO.',
+      text: "Oak, Jesse and Will, good morning, and Jesse, congrats on your first call as CFO."
     },
     {
-      end: 3687.2000000000003,
-
-      start: 3684.2400000000002,
-      text: 'Thank you.',
+      end: 3687.2,
+      start: 3684.24,
+      text: "Thank you."
     },
     {
       end: 3694.92,
-
-      start: 3687.2000000000003,
-      text: 'Oak, you provided several metrics for the 5G pre-provisioning.',
+      start: 3687.2,
+      text: "Oak, you provided several metrics for the 5G pre-provisioning."
     },
     {
       end: 3707.6,
-
       start: 3694.92,
-      text: 'What are the next technical milestones to look for with the 5G launch and is there risk that the launch could slip until early next year?',
+      text: "What are the next technical milestones to look for with the 5G launch and is there risk that the launch could slip until early next year?"
     },
     {
-      end: 3722.9199999999996,
-
+      end: 3722.92,
       start: 3707.6,
-      text: "Well, we're on track right now in terms of getting the chip fabrication completed at Samsung and getting that chip to GPT, AirSpan, and us on schedule.",
+      text: "Well, we're on track right now in terms of getting the chip fabrication completed at Samsung and getting that chip to GPT, AirSpan, and us on schedule."
     },
     {
       end: 3724.68,
-
-      start: 3722.9199999999996,
-      text: 'That looks to all be on schedule.',
+      start: 3722.92,
+      text: "That looks to all be on schedule."
     },
     {
       end: 3739.04,
-
       start: 3724.68,
-      text: "We've done almost all the testing one needs to do on this system already, but we have not tested as anything that just relates to the 5G chip, so clearly that testing has to take place, which will happen generally late second quarter, early third quarter.",
+      text: "We've done almost all the testing one needs to do on this system already, but we have not tested as anything that just relates to the 5G chip, so clearly that testing has to take place, which will happen generally late second quarter, early third quarter."
     },
     {
       end: 3742.72,
-
       start: 3739.04,
-      text: "We'll be flying it in the third quarter.",
+      text: "We'll be flying it in the third quarter."
     },
     {
       end: 3762.16,
-
       start: 3742.72,
-      text: "There's always the black swan possibility that something goes crazy at Samsung again or whatever, but with the amount of attention, Samsung, AirSpan, and GPT, and we have all paid to this chip at this point, it would be shocking if there was a problem with it.",
+      text: "There's always the black swan possibility that something goes crazy at Samsung again or whatever, but with the amount of attention, Samsung, AirSpan, and GPT, and we have all paid to this chip at this point, it would be shocking if there was a problem with it."
     },
     {
       end: 3770.48,
-
       start: 3762.16,
-      text: "So we're quite confident we'll be delivering in Q4, but now it appears to be completely on schedule.",
+      text: "So we're quite confident we'll be delivering in Q4, but now it appears to be completely on schedule."
     },
     {
       end: 3771.48,
-
       start: 3770.48,
-      text: 'Excellent.',
+      text: "Excellent."
     },
     {
       end: 3786.56,
-
       start: 3771.48,
-      text: 'And, Oak, you also discussed how the 5G service is expected to be five times to ten times faster than your current Avance ATG product.',
+      text: "And, Oak, you also discussed how the 5G service is expected to be five times to ten times faster than your current Avance ATG product."
     },
     {
       end: 3834.8,
-
       start: 3786.56,
-      text: 'And as it relates to small and midsize aircraft that only fly in the U.S., I know you were just talking about Textron aircraft, but do you think that those small and midsize aircraft would be good candidates for the global broadband product, or do you think that for small and midsize aircraft that only fly within the U.S., that most likely they will stick with your APG products as that appears to be fast enough for most of their needs as it relates to streaming, or video gaming, and phone calls, and whatnot?',
+      text: "And as it relates to small and midsize aircraft that only fly in the U.S., I know you were just talking about Textron aircraft, but do you think that those small and midsize aircraft would be good candidates for the global broadband product, or do you think that for small and midsize aircraft that only fly within the U.S., that most likely they will stick with your APG products as that appears to be fast enough for most of their needs as it relates to streaming, or video gaming, and phone calls, and whatnot?"
     },
     {
       end: 3840.56,
-
       start: 3834.8,
-      text: "Yeah, that's 100% right, Louis, and I think also it'll be priced to appeal to that market.",
+      text: "Yeah, that's 100% right, Louis, and I think also it'll be priced to appeal to that market."
     },
     {
       end: 3853.04,
-
       start: 3840.56,
-      text: 'So I think that ATG, if the mission is generally U.S., is a very good answer, and 5G is a very good answer.',
+      text: "So I think that ATG, if the mission is generally U.S., is a very good answer, and 5G is a very good answer."
     },
     {
-      end: 3855.2799999999997,
-
+      end: 3855.28,
       start: 3853.04,
-      text: "So that's where we're positioning that product.",
+      text: "So that's where we're positioning that product."
     },
     {
       end: 3862.68,
-
-      start: 3855.2799999999997,
-      text: "The GBB product we're really positioning for, obviously, the international planes that fly outside the U.S. most of the time.",
+      start: 3855.28,
+      text: "The GBB product we're really positioning for, obviously, the international planes that fly outside the U.S. most of the time."
     },
     {
       end: 3872.96,
-
       start: 3862.68,
-      text: 'For heavy jets in the U.S. that fly outside the U.S. often enough to want to have a system that can handle that overseas.',
+      text: "For heavy jets in the U.S. that fly outside the U.S. often enough to want to have a system that can handle that overseas."
     },
     {
       end: 3889.56,
-
       start: 3872.96,
-      text: "In that market today, we've already got, like in the heavy jet market, where over 50% of the U.S. heavies have our system, our ATG system on them today, probably about half of the heavy supermids have our system on them today, and a lot of those are advanced already.",
+      text: "In that market today, we've already got, like in the heavy jet market, where over 50% of the U.S. heavies have our system, our ATG system on them today, probably about half of the heavy supermids have our system on them today, and a lot of those are advanced already."
     },
     {
       end: 3898.68,
-
       start: 3889.56,
-      text: 'So for them to add a GBB is going to be a pretty easy lift, and it can replace their current geosatellite products.',
+      text: "So for them to add a GBB is going to be a pretty easy lift, and it can replace their current geosatellite products."
     },
     {
       end: 3900.72,
-
       start: 3898.68,
-      text: 'Then they have us and the geo product.',
+      text: "Then they have us and the geo product."
     },
     {
       end: 3913.16,
-
       start: 3900.72,
-      text: "So a lot of that market looks at this and says, I'd really love to have one throat to strangle, one provider, and one price for the bundled package that I can pay one bill.",
+      text: "So a lot of that market looks at this and says, I'd really love to have one throat to strangle, one provider, and one price for the bundled package that I can pay one bill."
     },
     {
       end: 3916.04,
-
       start: 3913.16,
-      text: 'And I think that Aliyah will provide a better service than geo.',
+      text: "And I think that Aliyah will provide a better service than geo."
     },
     {
       end: 3921.24,
-
       start: 3916.04,
-      text: "So that market, that's the other market where GBB is really aimed.",
+      text: "So that market, that's the other market where GBB is really aimed."
     },
     {
       end: 3922.24,
-
       start: 3921.24,
-      text: 'Great.',
+      text: "Great."
     },
     {
-      end: 3941.2799999999997,
-
+      end: 3941.28,
       start: 3922.24,
-      text: 'And one last one for Jesse, will there be a material step up in recurring cost of service expenses with the launch of 5G this year and the global broadband networks next year?',
+      text: "And one last one for Jesse, will there be a material step up in recurring cost of service expenses with the launch of 5G this year and the global broadband networks next year?"
     },
     {
       end: 3953.04,
-
-      start: 3941.2799999999997,
-      text: 'Will there be significantly higher backhaul costs and tower expenses and other data center software fees that we should be thinking about?',
+      start: 3941.28,
+      text: "Will there be significantly higher backhaul costs and tower expenses and other data center software fees that we should be thinking about?"
     },
     {
       end: 3970.32,
-
       start: 3953.04,
-      text: "I know Oak and Jesse have previously outlined expectations for significant margin expansion, and I'm just wondering what types of additional costs we should be thinking about.",
+      text: "I know Oak and Jesse have previously outlined expectations for significant margin expansion, and I'm just wondering what types of additional costs we should be thinking about."
     },
     {
       end: 3976.92,
-
       start: 3970.32,
-      text: "So 5G backhaul, it's in our guidance and it's in our long-term forecast that we've been providing.",
+      text: "So 5G backhaul, it's in our guidance and it's in our long-term forecast that we've been providing."
     },
     {
       end: 3980.92,
-
       start: 3976.92,
-      text: 'So there will be some increase in the 5G backhaul.',
+      text: "So there will be some increase in the 5G backhaul."
     },
     {
       end: 3992.4,
-
       start: 3980.92,
-      text: "And as mentioned with GBB, we're paying by the drink on that with OneWeb, so that would be flowing through the cost of service as well.",
+      text: "And as mentioned with GBB, we're paying by the drink on that with OneWeb, so that would be flowing through the cost of service as well."
     },
     {
       end: 3998.12,
-
       start: 3992.4,
-      text: 'But we still expect the margins to be in the 75 plus percent range in the long term.',
+      text: "But we still expect the margins to be in the 75 plus percent range in the long term."
     },
     {
       end: 4002.12,
-
       start: 3998.12,
-      text: "So that's included all in our plans.",
+      text: "So that's included all in our plans."
     },
     {
       end: 4003.12,
-
       start: 4002.12,
-      text: 'Great.',
+      text: "Great."
     },
     {
       end: 4004.12,
-
       start: 4003.12,
-      text: 'Thanks, Jesse.',
+      text: "Thanks, Jesse."
     },
     {
       end: 4007.56,
-
       start: 4004.12,
-      text: 'Thanks, Oak and Will.',
+      text: "Thanks, Oak and Will."
     },
     {
       end: 4008.56,
-
       start: 4007.56,
-      text: 'Thanks, Louis.',
+      text: "Thanks, Louis."
     },
     {
       end: 4009.56,
-
       start: 4008.56,
-      text: 'Thank you.',
+      text: "Thank you."
     },
     {
       end: 4010.56,
-
       start: 4009.56,
-      text: 'Thank you.',
+      text: "Thank you."
     },
     {
       end: 4018.12,
-
       start: 4010.56,
-      text: 'I would now like to turn the call back over to Vice President of Investor Relations, Will Davis, for any closing remarks.',
+      text: "I would now like to turn the call back over to Vice President of Investor Relations, Will Davis, for any closing remarks."
     },
     {
       end: 4021.08,
-
       start: 4018.12,
-      text: 'Thank you, everyone, for joining our first quarter earnings call.',
+      text: "Thank you, everyone, for joining our first quarter earnings call."
     },
     {
       end: 4037.52,
-
       start: 4021.08,
-      text: 'This now concludes our call, and you may disconnect.',
-    },
-  ],
+      text: "This now concludes our call, and you may disconnect."
+    }
+  ]
 };


### PR DESCRIPTION
Some timestamps have lots of decimals, which audio tag onTimeUpdate doesn't support. Rounding them so canidates don't get confused. 